### PR TITLE
Resolve display_rotator pages from repository scripts/ directory

### DIFF
--- a/display_rotator.py
+++ b/display_rotator.py
@@ -91,12 +91,14 @@ def parse_width() -> int:
 
 def resolve_script(path_like: str, base_dir: Path) -> str | None:
     path = Path(path_like)
-    if not path.is_absolute():
-        path = base_dir / path
-    if not path.exists():
-        print(f"[rotator] Skipping missing page: {path}", flush=True)
-        return None
-    return str(path)
+    candidates = [path] if path.is_absolute() else [base_dir / path, base_dir / "scripts" / path]
+
+    for candidate in candidates:
+        if candidate.exists():
+            return str(candidate)
+
+    print(f"[rotator] Skipping missing page: {candidates[0]}", flush=True)
+    return None
 
 
 def stop_child(child: subprocess.Popen[bytes] | None) -> None:


### PR DESCRIPTION
### Motivation
- Default page names (e.g. `piholestats_v1.0.py`) are stored under `scripts/`, but the rotator only checked the repo root which caused valid pages to be skipped.

### Description
- Update `resolve_script` to try both `base_dir/<name>` and `base_dir/scripts/<name>` for relative paths while keeping absolute-path handling unchanged.
- If neither candidate exists the function logs the missing page and returns `None`.

### Testing
- Ran a Python snippet that imports `display_rotator` and confirmed `resolve_script` successfully resolves a bare filename, a `scripts/`-prefixed relative path, and an absolute path to the existing files under `/workspace/zero2dash/scripts/` (all succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a32db0efb08320af80fd8581fdd8de)