### PR TITLE
Fix narrow touch-width midpoint regression on top of #17

### DIFF
--- a/display_rotator.py
+++ b/display_rotator.py
@@ -148,7 +148,7 @@ def detect_touch_width(device: str, default_width: int) -> int:
 
                 if max_val > min_val:
                     width = max_val - min_val + 1
-                    return max(default_width, width)
+                    return width
     except Exception as exc:
         print(f"[rotator] Touch width detection failed ({device}): {exc}", flush=True)
     return default_width


### PR DESCRIPTION
### Motivation
- Narrow touch panels reported an X range smaller than the configured default but were still using the larger default midpoint, causing left taps to be misclassified as `NEXT` instead of `PREV` when detection succeeded.

### Description
- Changed `detect_touch_width` in `display_rotator.py` to return the device-detected X-axis width directly when parsing `/sys/class/input/*/device/absinfo` succeeds. 
- Preserved the previous fallback behavior to the configured/default width when detection fails or data is invalid. 
- No other runtime logic was modified; `touch_worker` continues to compute the midpoint from the returned `device_touch_width`.

### Testing
- Compiled the module with `python3 -m py_compile display_rotator.py` and it succeeded. 
- Ran a small mocked test using `unittest.mock` that simulates `absinfo` lines for a 240-wide device and verified `detect_touch_width(..., 320)` returns `240`, and the test passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a34585b3ec83209d09d76190dacc83)