### PR TITLE
Fix detected touch width handling for narrow panels

### DIFF
--- a/display_rotator.py
+++ b/display_rotator.py
@@ -148,7 +148,7 @@ def detect_touch_width(device: str, default_width: int) -> int:
 
                 if max_val > min_val:
                     width = max_val - min_val + 1
-                    return max(default_width, width)
+                    return width
     except Exception as exc:
         print(f"[rotator] Touch width detection failed ({device}): {exc}", flush=True)
     return default_width


### PR DESCRIPTION
### Motivation
- Devices that report an X-axis range narrower than the configured default were still using the larger default midpoint, causing left-side taps to be misinterpreted as `NEXT` instead of `PREV`, so detection should use the actual device range when available.

### Description
- In `display_rotator.py` updated `detect_touch_width` to return the detected `width` directly when ABS X-axis info is available and only fall back to `default_width` when detection fails, ensuring midpoint comparisons use the real device range.

### Testing
- Ran `python -m py_compile display_rotator.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a345aa3c44832098e1f0fe626338a1)