### PR TITLE
Follow-up: parse absinfo axis IDs as hexadecimal for touch split detection

### DIFF
--- a/display_rotator.py
+++ b/display_rotator.py
@@ -131,9 +131,13 @@ def detect_touch_width(device: str, default_width: int) -> int:
                 if not payload:
                     continue
                 try:
-                    code = int(code_str.strip(), 0)
+                    raw_code = code_str.strip().lower()
+                    code = int(raw_code, 16)
                 except ValueError:
-                    continue
+                    try:
+                        code = int(code_str.strip(), 0)
+                    except ValueError:
+                        continue
                 if code not in (ABS_X, ABS_MT_POSITION_X):
                     continue
 


### PR DESCRIPTION
### Motivation
- Touch width auto-detection could miss `ABS_MT_POSITION_X` when `/sys/class/input/.../absinfo` emits axis IDs like `35` (hex-like without a `0x` prefix) because `int(code_str.strip(), 0)` parsed `35` as decimal 35 instead of hex 0x35, causing MT-only devices to fall back to the default width and breaking left/right tap splitting.

### Description
- Updated `detect_touch_width` in `display_rotator.py` to attempt parsing the `absinfo` axis ID as hexadecimal first (`int(raw_code, 16)`) and fall back to the previous auto-base parser (`int(..., 0)`) if that fails.
- Kept the existing min/max extraction and computed width logic intact so detected widths and midpoint split behavior remain unchanged once the axis is recognized.
- The change ensures IDs like `35` are interpreted as `0x35` (`ABS_MT_POSITION_X`) so MT-only touch devices detect the correct width.

### Testing
- Ran `python -m py_compile display_rotator.py` to verify the file compiles successfully (passed).
- Executed a small runtime assertion that parses `['00', '35', '0x35']` and confirmed the results are `[0, 53, 53]` to validate the new parsing behavior (passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a345cac198832094a9a9a4560f75b8)