### PR TITLE
Add image-only background page scripts and document rotator/backgrounds in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,13 @@ Environment variables:
 - `ROTATOR_PAGES` → optional legacy explicit page list override.
 
 If you have a dark-mode script such as `pihole-display-dark_v1.2.py`, keep it outside the rotator pages directory or leave it in the directory and rely on `ROTATOR_EXCLUDE_PATTERNS`.
+
+Image background test scripts
+The repository now includes image-only page scripts that can be used while building rotator functionality:
+
+- `scripts/weather-dash.py`
+- `scripts/calendash.py`
+- `scripts/google-photos.py`
+- `scripts/tram-info.py`
+
+Default backgrounds are loaded from the `images/` directory.

--- a/scripts/calendash.py
+++ b/scripts/calendash.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Display the calendash background image on the framebuffer."""
+
+import argparse
+import mmap
+import struct
+import sys
+from pathlib import Path
+
+from PIL import Image
+
+FBDEV_DEFAULT = "/dev/fb1"
+W, H = 320, 240
+DEFAULT_IMAGE = Path(__file__).resolve().parent.parent / "images" / "calendash-temp.png"
+
+
+def rgb888_to_rgb565(image: Image.Image) -> bytes:
+    r, g, b = image.split()
+    r = r.point(lambda value: value >> 3)
+    g = g.point(lambda value: value >> 2)
+    b = b.point(lambda value: value >> 3)
+
+    rgb565 = bytearray()
+    rp, gp, bp = r.tobytes(), g.tobytes(), b.tobytes()
+    for i in range(len(rp)):
+        value = ((rp[i] & 0x1F) << 11) | ((gp[i] & 0x3F) << 5) | (bp[i] & 0x1F)
+        rgb565 += struct.pack("<H", value)
+    return bytes(rgb565)
+
+
+def load_frame(image_path: Path) -> Image.Image:
+    if not image_path.exists():
+        raise FileNotFoundError(f"Background image not found: {image_path}")
+    return Image.open(image_path).convert("RGB").resize((W, H), Image.Resampling.LANCZOS)
+
+
+def write_to_framebuffer(image: Image.Image, fbdev: str) -> None:
+    payload = rgb888_to_rgb565(image)
+    with open(fbdev, "r+b", buffering=0) as framebuffer:
+        mm = mmap.mmap(framebuffer.fileno(), W * H * 2, mmap.MAP_SHARED, mmap.PROT_WRITE)
+        mm.seek(0)
+        mm.write(payload)
+        mm.close()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Display calendash background image on TFT framebuffer.")
+    parser.add_argument("--image", default=str(DEFAULT_IMAGE), help=f"Background image path (default: {DEFAULT_IMAGE})")
+    parser.add_argument("--fbdev", default=FBDEV_DEFAULT, help=f"Framebuffer device path (default: {FBDEV_DEFAULT})")
+    parser.add_argument("--output", help="Optional output image path for local verification (PNG/JPG)")
+    parser.add_argument("--no-framebuffer", action="store_true", help="Skip framebuffer write (useful for local testing).")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    try:
+        frame = load_frame(Path(args.image))
+    except FileNotFoundError as exc:
+        print(exc, file=sys.stderr)
+        return 1
+
+    if args.output:
+        frame.save(args.output)
+        print(f"Saved preview image to {args.output}")
+
+    if args.no_framebuffer:
+        print("Skipping framebuffer write (--no-framebuffer set)")
+        return 0
+
+    fb_path = Path(args.fbdev)
+    if not fb_path.exists():
+        print(f"Framebuffer {args.fbdev} not found.", file=sys.stderr)
+        return 1
+
+    write_to_framebuffer(frame, args.fbdev)
+    print(f"Displayed calendash background on {args.fbdev}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/google-photos.py
+++ b/scripts/google-photos.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Display the google-photos background image on the framebuffer."""
+
+import argparse
+import mmap
+import struct
+import sys
+from pathlib import Path
+
+from PIL import Image
+
+FBDEV_DEFAULT = "/dev/fb1"
+W, H = 320, 240
+DEFAULT_IMAGE = Path(__file__).resolve().parent.parent / "images" / "google-photos-temp.png"
+
+
+def rgb888_to_rgb565(image: Image.Image) -> bytes:
+    r, g, b = image.split()
+    r = r.point(lambda value: value >> 3)
+    g = g.point(lambda value: value >> 2)
+    b = b.point(lambda value: value >> 3)
+
+    rgb565 = bytearray()
+    rp, gp, bp = r.tobytes(), g.tobytes(), b.tobytes()
+    for i in range(len(rp)):
+        value = ((rp[i] & 0x1F) << 11) | ((gp[i] & 0x3F) << 5) | (bp[i] & 0x1F)
+        rgb565 += struct.pack("<H", value)
+    return bytes(rgb565)
+
+
+def load_frame(image_path: Path) -> Image.Image:
+    if not image_path.exists():
+        raise FileNotFoundError(f"Background image not found: {image_path}")
+    return Image.open(image_path).convert("RGB").resize((W, H), Image.Resampling.LANCZOS)
+
+
+def write_to_framebuffer(image: Image.Image, fbdev: str) -> None:
+    payload = rgb888_to_rgb565(image)
+    with open(fbdev, "r+b", buffering=0) as framebuffer:
+        mm = mmap.mmap(framebuffer.fileno(), W * H * 2, mmap.MAP_SHARED, mmap.PROT_WRITE)
+        mm.seek(0)
+        mm.write(payload)
+        mm.close()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Display google-photos background image on TFT framebuffer.")
+    parser.add_argument("--image", default=str(DEFAULT_IMAGE), help=f"Background image path (default: {DEFAULT_IMAGE})")
+    parser.add_argument("--fbdev", default=FBDEV_DEFAULT, help=f"Framebuffer device path (default: {FBDEV_DEFAULT})")
+    parser.add_argument("--output", help="Optional output image path for local verification (PNG/JPG)")
+    parser.add_argument("--no-framebuffer", action="store_true", help="Skip framebuffer write (useful for local testing).")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    try:
+        frame = load_frame(Path(args.image))
+    except FileNotFoundError as exc:
+        print(exc, file=sys.stderr)
+        return 1
+
+    if args.output:
+        frame.save(args.output)
+        print(f"Saved preview image to {args.output}")
+
+    if args.no_framebuffer:
+        print("Skipping framebuffer write (--no-framebuffer set)")
+        return 0
+
+    fb_path = Path(args.fbdev)
+    if not fb_path.exists():
+        print(f"Framebuffer {args.fbdev} not found.", file=sys.stderr)
+        return 1
+
+    write_to_framebuffer(frame, args.fbdev)
+    print(f"Displayed google-photos background on {args.fbdev}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tram-info.py
+++ b/scripts/tram-info.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Display the tram-info background image on the framebuffer."""
+
+import argparse
+import mmap
+import struct
+import sys
+from pathlib import Path
+
+from PIL import Image
+
+FBDEV_DEFAULT = "/dev/fb1"
+W, H = 320, 240
+DEFAULT_IMAGE = Path(__file__).resolve().parent.parent / "images" / "bee-net-temp.png"
+
+
+def rgb888_to_rgb565(image: Image.Image) -> bytes:
+    r, g, b = image.split()
+    r = r.point(lambda value: value >> 3)
+    g = g.point(lambda value: value >> 2)
+    b = b.point(lambda value: value >> 3)
+
+    rgb565 = bytearray()
+    rp, gp, bp = r.tobytes(), g.tobytes(), b.tobytes()
+    for i in range(len(rp)):
+        value = ((rp[i] & 0x1F) << 11) | ((gp[i] & 0x3F) << 5) | (bp[i] & 0x1F)
+        rgb565 += struct.pack("<H", value)
+    return bytes(rgb565)
+
+
+def load_frame(image_path: Path) -> Image.Image:
+    if not image_path.exists():
+        raise FileNotFoundError(f"Background image not found: {image_path}")
+    return Image.open(image_path).convert("RGB").resize((W, H), Image.Resampling.LANCZOS)
+
+
+def write_to_framebuffer(image: Image.Image, fbdev: str) -> None:
+    payload = rgb888_to_rgb565(image)
+    with open(fbdev, "r+b", buffering=0) as framebuffer:
+        mm = mmap.mmap(framebuffer.fileno(), W * H * 2, mmap.MAP_SHARED, mmap.PROT_WRITE)
+        mm.seek(0)
+        mm.write(payload)
+        mm.close()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Display tram-info background image on TFT framebuffer.")
+    parser.add_argument("--image", default=str(DEFAULT_IMAGE), help=f"Background image path (default: {DEFAULT_IMAGE})")
+    parser.add_argument("--fbdev", default=FBDEV_DEFAULT, help=f"Framebuffer device path (default: {FBDEV_DEFAULT})")
+    parser.add_argument("--output", help="Optional output image path for local verification (PNG/JPG)")
+    parser.add_argument("--no-framebuffer", action="store_true", help="Skip framebuffer write (useful for local testing).")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    try:
+        frame = load_frame(Path(args.image))
+    except FileNotFoundError as exc:
+        print(exc, file=sys.stderr)
+        return 1
+
+    if args.output:
+        frame.save(args.output)
+        print(f"Saved preview image to {args.output}")
+
+    if args.no_framebuffer:
+        print("Skipping framebuffer write (--no-framebuffer set)")
+        return 0
+
+    fb_path = Path(args.fbdev)
+    if not fb_path.exists():
+        print(f"Framebuffer {args.fbdev} not found.", file=sys.stderr)
+        return 1
+
+    write_to_framebuffer(frame, args.fbdev)
+    print(f"Displayed tram-info background on {args.fbdev}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/weather-dash.py
+++ b/scripts/weather-dash.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Display the weather-dash background image on the framebuffer."""
+
+import argparse
+import mmap
+import struct
+import sys
+from pathlib import Path
+
+from PIL import Image
+
+FBDEV_DEFAULT = "/dev/fb1"
+W, H = 320, 240
+DEFAULT_IMAGE = Path(__file__).resolve().parent.parent / "images" / "weather-dash-temp.png"
+
+
+def rgb888_to_rgb565(image: Image.Image) -> bytes:
+    r, g, b = image.split()
+    r = r.point(lambda value: value >> 3)
+    g = g.point(lambda value: value >> 2)
+    b = b.point(lambda value: value >> 3)
+
+    rgb565 = bytearray()
+    rp, gp, bp = r.tobytes(), g.tobytes(), b.tobytes()
+    for i in range(len(rp)):
+        value = ((rp[i] & 0x1F) << 11) | ((gp[i] & 0x3F) << 5) | (bp[i] & 0x1F)
+        rgb565 += struct.pack("<H", value)
+    return bytes(rgb565)
+
+
+def load_frame(image_path: Path) -> Image.Image:
+    if not image_path.exists():
+        raise FileNotFoundError(f"Background image not found: {image_path}")
+    return Image.open(image_path).convert("RGB").resize((W, H), Image.Resampling.LANCZOS)
+
+
+def write_to_framebuffer(image: Image.Image, fbdev: str) -> None:
+    payload = rgb888_to_rgb565(image)
+    with open(fbdev, "r+b", buffering=0) as framebuffer:
+        mm = mmap.mmap(framebuffer.fileno(), W * H * 2, mmap.MAP_SHARED, mmap.PROT_WRITE)
+        mm.seek(0)
+        mm.write(payload)
+        mm.close()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Display weather-dash background image on TFT framebuffer.")
+    parser.add_argument("--image", default=str(DEFAULT_IMAGE), help=f"Background image path (default: {DEFAULT_IMAGE})")
+    parser.add_argument("--fbdev", default=FBDEV_DEFAULT, help=f"Framebuffer device path (default: {FBDEV_DEFAULT})")
+    parser.add_argument("--output", help="Optional output image path for local verification (PNG/JPG)")
+    parser.add_argument("--no-framebuffer", action="store_true", help="Skip framebuffer write (useful for local testing).")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    try:
+        frame = load_frame(Path(args.image))
+    except FileNotFoundError as exc:
+        print(exc, file=sys.stderr)
+        return 1
+
+    if args.output:
+        frame.save(args.output)
+        print(f"Saved preview image to {args.output}")
+
+    if args.no_framebuffer:
+        print("Skipping framebuffer write (--no-framebuffer set)")
+        return 0
+
+    fb_path = Path(args.fbdev)
+    if not fb_path.exists():
+        print(f"Framebuffer {args.fbdev} not found.", file=sys.stderr)
+        return 1
+
+    write_to_framebuffer(frame, args.fbdev)
+    print(f"Displayed weather-dash background on {args.fbdev}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- Provide simple image-only page scripts to aid building and testing the display rotator and to allow previewing backgrounds without full dashboard logic.
- Document the rotator directory-based discovery and list the new image background scripts in `README.md` so defaults and locations are clear.

### Description

- Add four new executable scripts: `scripts/calendash.py`, `scripts/weather-dash.py`, `scripts/google-photos.py`, and `scripts/tram-info.py`, each of which loads a default image from `images/`, resizes to `320x240`, converts to RGB565 and writes to the framebuffer.
- Each script provides a CLI with `--image`, `--fbdev`, `--output`, and `--no-framebuffer` options and uses Pillow for image handling and `mmap` for framebuffer writes.
- Update `README.md` to document the rotator environment variables (`ROTATOR_PAGES_DIR`, `ROTATOR_PAGE_GLOB`, `ROTATOR_EXCLUDE_PATTERNS`, `ROTATOR_PAGES`) and add a short section listing the new image background test scripts and the `images/` directory as the default background source.

### Testing

- Ran smoke-preview tests for each script using `python3 scripts/<name>.py --output /tmp/<name>.png --no-framebuffer` which produced preview images successfully for `calendash`, `weather-dash`, `google-photos`, and `tram-info`.
- Framebuffer write paths were exercised only with `--no-framebuffer` during automated checks; framebuffer access was not required for these automated runs and no framebuffer write tests were executed in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a351a8e13c8320bc541bcef8e5259f)