### PR TITLE
Support multiple ROTATOR_PAGE_GLOB patterns and update defaults/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ Display rotator configuration
 
 Environment variables:
 - `ROTATOR_PAGES_DIR` (default: `scripts`) → directory to scan for pages.
-- `ROTATOR_PAGE_GLOB` (default: `piholestats_v*.py`) → file pattern inside that directory. Set to `*.py` if you want to rotate arbitrary dashboards or test pages.
-- `ROTATOR_EXCLUDE_PATTERNS` (default: `pihole-display-dark*.py`) → comma-separated filename patterns to skip.
+- `ROTATOR_PAGE_GLOB` (default: `*.py`) → file pattern(s) inside that directory. You can pass a comma-separated list such as `piholestats_v*.py,*-dash.py`.
+- `ROTATOR_EXCLUDE_PATTERNS` (default: `piholestats_v1.2.py`) → comma-separated filename patterns to skip.
 - `ROTATOR_PAGES` → optional legacy explicit page list override.
 
 If you have a dark-mode script such as `pihole-display-dark_v1.2.py`, keep it outside the rotator pages directory or leave it in the directory and rely on `ROTATOR_EXCLUDE_PATTERNS`.

--- a/display_rotator.py
+++ b/display_rotator.py
@@ -26,8 +26,8 @@ from pathlib import Path
 
 
 DEFAULT_PAGES_DIR = "scripts"
-DEFAULT_PAGE_GLOB = "piholestats_v*.py"
-DEFAULT_EXCLUDE_PATTERNS = ["pihole-display-dark*.py"]
+DEFAULT_PAGE_GLOB = "*.py"
+DEFAULT_EXCLUDE_PATTERNS = ["piholestats_v1.2.py"]
 DEFAULT_ROTATE_SECS = 30
 SHUTDOWN_WAIT_SECS = 5
 DEFAULT_FBDEV = "/dev/fb1"
@@ -74,7 +74,8 @@ def parse_exclude_patterns() -> list[str]:
 
 def discover_pages(base_dir: Path) -> list[str]:
     page_dir_raw = os.environ.get("ROTATOR_PAGES_DIR", DEFAULT_PAGES_DIR).strip() or DEFAULT_PAGES_DIR
-    page_glob = os.environ.get("ROTATOR_PAGE_GLOB", DEFAULT_PAGE_GLOB).strip() or DEFAULT_PAGE_GLOB
+    page_glob_raw = os.environ.get("ROTATOR_PAGE_GLOB", DEFAULT_PAGE_GLOB).strip() or DEFAULT_PAGE_GLOB
+    page_globs = [entry.strip() for entry in page_glob_raw.split(",") if entry.strip()]
     excludes = parse_exclude_patterns()
 
     page_dir = Path(page_dir_raw)
@@ -86,12 +87,15 @@ def discover_pages(base_dir: Path) -> list[str]:
         return []
 
     discovered: list[str] = []
-    for path in sorted(page_dir.glob(page_glob)):
-        if not path.is_file():
-            continue
-        if any(path.match(pattern) or path.name == pattern for pattern in excludes):
-            continue
-        discovered.append(str(path.relative_to(base_dir)))
+    seen: set[Path] = set()
+    for page_glob in page_globs:
+        for path in sorted(page_dir.glob(page_glob)):
+            if not path.is_file() or path in seen:
+                continue
+            seen.add(path)
+            if any(path.match(pattern) or path.name == pattern for pattern in excludes):
+                continue
+            discovered.append(str(path.relative_to(base_dir)))
 
     return discovered
 


### PR DESCRIPTION
### Motivation
- Make the rotator discover arbitrary page scripts by default and allow multiple glob patterns so users don't need to list every script manually.
- Provide a clearer default behavior and example usage for `ROTATOR_PAGE_GLOB` and `ROTATOR_EXCLUDE_PATTERNS` in the documentation.

### Description
- Change default page discovery glob from `piholestats_v*.py` to `*.py` and update the default exclude pattern constant in `display_rotator.py`.
- Parse `ROTATOR_PAGE_GLOB` as a comma-separated list of glob patterns and iterate each pattern when discovering pages in `discover_pages()`.
- Add a `seen` set to avoid duplicate entries when multiple globs match the same file and preserve relative paths for discovered pages.
- Update `README.md` to document the new `ROTATOR_PAGE_GLOB` behavior, show example comma-separated patterns, and adjust the `ROTATOR_EXCLUDE_PATTERNS` documentation.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a354e00b448320ba19a1a0192cec97)