### PR TITLE
Harden runtime config: remove hardcoded Pi-hole secrets and use env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Copy this file to .env and update values for your environment.
+# Never commit real secrets.
+
+# Pi-hole API endpoint (hostname or IP)
+PIHOLE_HOST=192.168.1.2
+
+# Pi-hole admin password used for v6 API auth
+PIHOLE_PASSWORD=replace-with-your-pihole-password
+
+# Optional runtime tuning
+REFRESH_SECS=3
+# ACTIVE_HOURS as start,end (24h) e.g. 22,7
+ACTIVE_HOURS=22,7

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__/
 *.pyc
+.env
+.env.local

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ zero2dash/
 │   ├── piholestats_v1.2.py
 │   └── test.py
 ├── systemd/
-│   ├── pihole-display.service
+│   ├── display.service
 │   ├── pihole-display-dark.service
 │   ├── day.timer
 │   └── night.timer
@@ -38,18 +38,31 @@ sudo cp -r . /opt/zero2dash/
 sudo chmod +x /opt/zero2dash/scripts/pihole-display-pre.sh
 sudo chmod +x /opt/zero2dash/scripts/test.py
 Configure
-Edit in /opt/zero2dash/scripts/piholestats_v1.2.py:
+Create an environment file and keep secrets out of source control:
+
+cp /opt/zero2dash/.env.example /opt/zero2dash/.env
+chmod 600 /opt/zero2dash/.env
+
+Edit `/opt/zero2dash/.env` and set:
 
 PIHOLE_HOST
 PIHOLE_PASSWORD
 REFRESH_SECS
+ACTIVE_HOURS
 Run via systemd
-sudo cp /opt/zero2dash/systemd/pihole-display*.service /etc/systemd/system/
+If you run scripts manually, load env vars first:
+
+set -a
+source /opt/zero2dash/.env
+set +a
+
+sudo cp /opt/zero2dash/systemd/display.service /etc/systemd/system/
+sudo cp /opt/zero2dash/systemd/pihole-display-dark.service /etc/systemd/system/
 sudo systemctl daemon-reload
-sudo systemctl enable --now pihole-display.service
+sudo systemctl enable --now display.service
 Check logs:
 
-journalctl -u pihole-display.service -n 50 --no-pager
+journalctl -u display.service -n 50 --no-pager
 Placeholder test script
 To verify basic rendering logic:
 

--- a/scripts/piholestats_v1.1.py
+++ b/scripts/piholestats_v1.1.py
@@ -14,8 +14,8 @@ W, H = 320, 240
 REFRESH_SECS = 3
 ACTIVE_HOURS = (7, 22)
 
-PIHOLE_HOST = "192.168.31.16"
-PIHOLE_PASSWORD = "Unf0rg1v3n2"   # not used directly here; kept for context
+PIHOLE_HOST = os.environ.get("PIHOLE_HOST", "127.0.0.1")
+PIHOLE_PASSWORD = os.environ.get("PIHOLE_PASSWORD", "")
 TITLE = "Pi-hole"
 # Colours
 COL_BG   = (0, 0, 0)
@@ -29,6 +29,33 @@ COL_UP   = (60,30,100)
 
 _SID = None
 _SID_EXP = 0.0
+
+
+def _env_int(name, default):
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+def _env_hours(name, default):
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    parts = [part.strip() for part in raw.split(",")]
+    if len(parts) != 2:
+        return default
+    try:
+        return int(parts[0]), int(parts[1])
+    except ValueError:
+        return default
+
+
+REFRESH_SECS = max(1, _env_int("REFRESH_SECS", REFRESH_SECS))
+ACTIVE_HOURS = _env_hours("ACTIVE_HOURS", ACTIVE_HOURS)
 
 # ---------- utils ----------
 def load_font(size, bold=False):
@@ -101,6 +128,8 @@ def _http_json(url, method="GET", body=None, timeout=3):
 
 def _auth_get_sid():
     global _SID, _SID_EXP
+    if not PIHOLE_PASSWORD:
+        raise RuntimeError("Missing PIHOLE_PASSWORD")
     js = _http_json(f"http://{PIHOLE_HOST}/api/auth", method="POST",
                     body={"password": PIHOLE_PASSWORD}, timeout=4)
     sess = js.get("session", {})

--- a/scripts/piholestats_v1.2.py
+++ b/scripts/piholestats_v1.2.py
@@ -14,8 +14,8 @@ W, H = 320, 240
 REFRESH_SECS = 3
 ACTIVE_HOURS = (22, 7)
 
-PIHOLE_HOST = "192.168.31.16"
-PIHOLE_PASSWORD = "Unf0rg1v3n2"
+PIHOLE_HOST = os.environ.get("PIHOLE_HOST", "127.0.0.1")
+PIHOLE_PASSWORD = os.environ.get("PIHOLE_PASSWORD", "")
 TITLE = "Pi-hole"
 COL_BG   = (0, 0, 0)
 COL_TXT  = (140,140,140)
@@ -27,6 +27,33 @@ COL_UP   = (24,12,40)
 
 _SID = None
 _SID_EXP = 0.0
+
+
+def _env_int(name, default):
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+def _env_hours(name, default):
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    parts = [part.strip() for part in raw.split(",")]
+    if len(parts) != 2:
+        return default
+    try:
+        return int(parts[0]), int(parts[1])
+    except ValueError:
+        return default
+
+
+REFRESH_SECS = max(1, _env_int("REFRESH_SECS", REFRESH_SECS))
+ACTIVE_HOURS = _env_hours("ACTIVE_HOURS", ACTIVE_HOURS)
 
 # ---------- utils ----------
 def load_font(size, bold=False):
@@ -99,6 +126,8 @@ def _http_json(url, method="GET", body=None, timeout=3):
 
 def _auth_get_sid():
     global _SID, _SID_EXP
+    if not PIHOLE_PASSWORD:
+        raise RuntimeError("Missing PIHOLE_PASSWORD")
     js = _http_json(f"http://{PIHOLE_HOST}/api/auth", method="POST",
                     body={"password": PIHOLE_PASSWORD}, timeout=4)
     sess = js.get("session", {})

--- a/systemd/display.service
+++ b/systemd/display.service
@@ -1,28 +1,17 @@
 [Unit]
-<<<<<<< HEAD:systemd/pihole-display.service
-Description=Pi-hole TFT Stats Display
-=======
 Description=Pi-hole TFT Day Display Rotator
->>>>>>> main:systemd/display.service
 After=network-online.target dev-fb1.device
 Wants=network-online.target dev-fb1.device
 ConditionPathExists=/dev/fb1
 
 [Service]
 Type=simple
-<<<<<<< HEAD:systemd/pihole-display.service
 WorkingDirectory=/opt/zero2dash
 Environment=PYTHONUNBUFFERED=1
+EnvironmentFile=-/opt/zero2dash/.env
 
 ExecStartPre=/opt/zero2dash/scripts/pihole-display-pre.sh
-ExecStart=/usr/bin/python3 -u /opt/zero2dash/scripts/piholestats_v1.1.py
-=======
-WorkingDirectory=/home/pihole
-Environment=PYTHONUNBUFFERED=1
-
-ExecStartPre=/usr/local/bin/pihole-display-pre.sh
-ExecStart=/usr/bin/python3 -u /home/pihole/display_rotator.py
->>>>>>> main:systemd/display.service
+ExecStart=/usr/bin/python3 -u /opt/zero2dash/display_rotator.py
 
 Restart=always
 RestartSec=2

--- a/systemd/pihole-display-dark.service
+++ b/systemd/pihole-display-dark.service
@@ -8,6 +8,7 @@ ConditionPathExists=/dev/fb1
 Type=simple
 WorkingDirectory=/opt/zero2dash
 Environment=PYTHONUNBUFFERED=1
+EnvironmentFile=-/opt/zero2dash/.env
 
 ExecStartPre=/opt/zero2dash/scripts/pihole-display-pre.sh
 ExecStart=/usr/bin/python3 -u /opt/zero2dash/scripts/piholestats_v1.2.py


### PR DESCRIPTION
### Motivation
- Remove hardcoded Pi-hole host/password and avoid committing secrets in source control.  
- Allow runtime tuning via environment variables and make service units load secrets from a single `.env` file.  

### Description
- Replaced hardcoded `PIHOLE_HOST` and `PIHOLE_PASSWORD` in `scripts/piholestats_v1.1.py` and `scripts/piholestats_v1.2.py` with `os.environ.get(...)` lookups.  
- Added a guard in `_auth_get_sid()` to raise `RuntimeError("Missing PIHOLE_PASSWORD")` when the password is not set.  
- Added helper functions `_env_int` and `_env_hours` and wired `REFRESH_SECS` and `ACTIVE_HOURS` to environment overrides.  
- Added `.env.example` as a template for sensitive runtime config and updated `.gitignore` to exclude `.env` and `.env.local`.  
- Updated `systemd/display.service` and `systemd/pihole-display-dark.service` to use `EnvironmentFile=-/opt/zero2dash/.env` and fixed the day service to run the rotator at `/opt/zero2dash/display_rotator.py`.  
- Updated `README.md` to document the `.env` workflow and updated service installation/run instructions.  

### Testing
- Ran `python -m compileall scripts display_rotator.py` to ensure files compile and it completed successfully.  
- Searched the repository for common secret patterns (passwords, API keys, private key markers) with ripgrep and confirmed no hardcoded Pi-hole password or obvious secret patterns remain.  
- Basic repository sanity checks (updated `.gitignore`, created `.env.example`, and validated modified unit files) were performed to ensure expected changes are present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3570cbe8c8320bdd916b876c8d935)