### PR TITLE
Add Google Calendar image generator and documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,22 @@
 # Copy this file to .env and update values for your environment.
 # Never commit real secrets.
 
+# --- Google Calendar (calendash-api.py) ---
+# OAuth2 Desktop client credentials from Google Cloud console.
+GOOGLE_CLIENT_ID=replace-with-google-client-id.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=replace-with-google-client-secret
+# Use "primary" for your personal primary calendar.
+GOOGLE_CALENDAR_ID=primary
+# Output PNG path (script deletes old file before writing a new one).
+OUTPUT_PATH=~/zero2dash/images/calendash/output.png
+# 320x240 base background image (contains Calendar logo/header area).
+BACKGROUND_IMAGE=~/zero2dash/images/calendash-bkg.png
+# Event row icon image (small, transparent PNG preferred).
+ICON_IMAGE=~/zero2dash/images/calendash-icon.png
+# Local timezone used for date window and formatting.
+TIMEZONE=Europe/London
+
+# --- Pi-hole dashboard settings (existing scripts) ---
 # Pi-hole API endpoint (hostname or IP, with or without http://)
 PIHOLE_HOST=192.168.1.2
 

--- a/README.md
+++ b/README.md
@@ -172,3 +172,53 @@ Touch controls and static pages
 - Single tap left/right changes page.
 - Double tap toggles screen power: OFF blanks/powers down the panel output, ON restores panel output. The rotator and page scripts keep running in both states (falls back to `vcgencmd display_power` when framebuffer blanking is unsupported).
 - Image-only scripts can exit immediately; the rotator now keeps each page on-screen for `ROTATOR_SECS` unless you tap to switch.
+
+## Google Calendar image generator (`scripts/calendash-api.py`)
+
+This script creates a daily 320×240 PNG summary of upcoming Google Calendar events for TFT display rotation.
+
+### Install dependencies
+
+```sh
+python3 -m pip install google-api-python-client google-auth-oauthlib python-dotenv pillow pytz
+```
+
+### Configure
+
+1. Copy and edit env file:
+
+   ```sh
+   cp .env.example .env
+   chmod 600 .env
+   ```
+
+2. Set these variables in `.env`:
+   - `GOOGLE_CLIENT_ID`
+   - `GOOGLE_CLIENT_SECRET`
+   - `GOOGLE_CALENDAR_ID` (for personal calendar use `primary`)
+   - `OUTPUT_PATH`
+   - `BACKGROUND_IMAGE`
+   - `ICON_IMAGE`
+   - `TIMEZONE` (example: `Europe/London`)
+
+3. Place your assets:
+   - `BACKGROUND_IMAGE`: 320×240 background containing the Google Calendar logo/header.
+   - `ICON_IMAGE`: small calendar icon used in each event row.
+
+### First run (OAuth)
+
+Run once manually to complete OAuth2 login and create `token.json` in the repo root:
+
+```sh
+python3 scripts/calendash-api.py
+```
+
+After first auth, future runs refresh tokens automatically and are suitable for headless cron execution.
+
+### Daily cron at 06:00 (local time)
+
+```cron
+0 6 * * * cd /opt/zero2dash && /usr/bin/python3 /opt/zero2dash/scripts/calendash-api.py >> /var/log/calendash.log 2>&1
+```
+
+The script fetches events from **today 00:00** to **+3 calendar days 23:59**, retries API/network failures with exponential backoff, and writes either the event summary image, a no-events image, or an error image.

--- a/scripts/calendash-api.py
+++ b/scripts/calendash-api.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""Generate a 320x240 Google Calendar summary image for a Raspberry Pi TFT display.
+
+Dependencies:
+  pip install google-api-python-client google-auth-oauthlib python-dotenv pillow pytz
+
+Cron example (06:00 every day):
+  0 6 * * * cd /opt/zero2dash && /usr/bin/python3 /opt/zero2dash/scripts/calendash-api.py >> /var/log/calendash.log 2>&1
+
+Assets:
+- BACKGROUND_IMAGE should be a 320x240 base image that already contains your logo/header.
+- ICON_IMAGE should be a small calendar icon with transparency.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from dataclasses import dataclass
+from datetime import date, datetime, time as dt_time, timedelta
+from pathlib import Path
+from typing import Any, Iterable
+
+import pytz
+from dotenv import load_dotenv
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+from PIL import Image, ImageDraw, ImageFont
+
+SCOPES = ["https://www.googleapis.com/auth/calendar.readonly"]
+CANVAS_WIDTH = 320
+CANVAS_HEIGHT = 240
+TOKEN_PATH = Path("token.json")
+
+
+@dataclass
+class CalendarEvent:
+    starts_at: datetime
+    display_date: str
+    summary: str
+    all_day: bool
+
+
+def configure_logging() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+
+def required_env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        raise ValueError(f"Missing required env variable: {name}")
+    return value
+
+
+def expand_path(value: str) -> Path:
+    return Path(value).expanduser().resolve()
+
+
+def load_font(preferred_size: int) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
+    candidates = [
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+        "/usr/share/fonts/truetype/liberation2/LiberationSans-Bold.ttf",
+        "/usr/share/fonts/truetype/freefont/FreeSansBold.ttf",
+    ]
+    for candidate in candidates:
+        if Path(candidate).exists():
+            return ImageFont.truetype(candidate, preferred_size)
+    logging.warning("No bold TTF font found; using PIL default font.")
+    return ImageFont.load_default()
+
+
+def build_client_config(client_id: str, client_secret: str) -> dict[str, Any]:
+    return {
+        "installed": {
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+            "token_uri": "https://oauth2.googleapis.com/token",
+            "redirect_uris": ["http://localhost", "urn:ietf:wg:oauth:2.0:oob"],
+        }
+    }
+
+
+def save_credentials(creds: Credentials, token_path: Path) -> None:
+    token_path.write_text(creds.to_json(), encoding="utf-8")
+    os.chmod(token_path, 0o600)
+
+
+def get_credentials(client_id: str, client_secret: str, token_path: Path) -> Credentials:
+    creds: Credentials | None = None
+
+    if token_path.exists():
+        creds = Credentials.from_authorized_user_file(str(token_path), SCOPES)
+
+    if creds and creds.valid:
+        return creds
+
+    if creds and creds.expired and creds.refresh_token:
+        logging.info("Refreshing existing OAuth token.")
+        creds.refresh(Request())
+        save_credentials(creds, token_path)
+        return creds
+
+    logging.info("Starting first-run OAuth flow (console mode).")
+    flow = InstalledAppFlow.from_client_config(
+        build_client_config(client_id, client_secret),
+        SCOPES,
+    )
+    creds = flow.run_console()
+    save_credentials(creds, token_path)
+    return creds
+
+
+def parse_event_start(raw_event: dict[str, Any], tz_obj: pytz.BaseTzInfo) -> tuple[datetime, bool]:
+    start = raw_event.get("start", {})
+    date_time_val = start.get("dateTime")
+    date_val = start.get("date")
+
+    if date_time_val:
+        parsed = datetime.fromisoformat(date_time_val.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = tz_obj.localize(parsed)
+        return parsed.astimezone(tz_obj), False
+
+    if date_val:
+        parsed_date = date.fromisoformat(date_val)
+        localized_midnight = tz_obj.localize(datetime.combine(parsed_date, dt_time.min))
+        return localized_midnight, True
+
+    raise ValueError("Event missing both start.dateTime and start.date")
+
+
+def fetch_events(
+    service: Any,
+    calendar_id: str,
+    tz_name: str,
+    retries: int = 3,
+) -> list[CalendarEvent]:
+    tz_obj = pytz.timezone(tz_name)
+    now_local = datetime.now(tz_obj)
+    start_local = tz_obj.localize(datetime.combine(now_local.date(), dt_time.min))
+    end_local = tz_obj.localize(datetime.combine(now_local.date() + timedelta(days=3), dt_time(23, 59, 59)))
+
+    params = {
+        "calendarId": calendar_id,
+        "timeMin": start_local.astimezone(pytz.UTC).isoformat(),
+        "timeMax": end_local.astimezone(pytz.UTC).isoformat(),
+        "singleEvents": True,
+        "orderBy": "startTime",
+        "maxResults": 250,
+    }
+
+    last_error: Exception | None = None
+    for attempt in range(1, retries + 1):
+        try:
+            logging.info(
+                "Fetching events from %s to %s (%s), attempt %d/%d",
+                start_local.isoformat(),
+                end_local.isoformat(),
+                tz_name,
+                attempt,
+                retries,
+            )
+            response = service.events().list(**params).execute()
+            raw_events = response.get("items", [])
+            parsed: list[CalendarEvent] = []
+            for raw in raw_events:
+                starts_at, all_day = parse_event_start(raw, tz_obj)
+                parsed.append(
+                    CalendarEvent(
+                        starts_at=starts_at,
+                        display_date=starts_at.strftime("%d/%m"),
+                        summary=(raw.get("summary") or "(No title)").strip(),
+                        all_day=all_day,
+                    )
+                )
+            parsed.sort(key=lambda event: event.starts_at)
+            return parsed
+        except (HttpError, OSError, TimeoutError) as exc:
+            last_error = exc
+            wait_s = 2 ** (attempt - 1)
+            logging.error("Fetch failed (attempt %d/%d): %s", attempt, retries, exc)
+            if attempt < retries:
+                logging.info("Retrying in %d seconds...", wait_s)
+                time.sleep(wait_s)
+
+    assert last_error is not None
+    raise RuntimeError("Failed to fetch calendar events after retries") from last_error
+
+
+def truncate_text(draw: ImageDraw.ImageDraw, text: str, font: ImageFont.ImageFont, max_width: int) -> str:
+    if draw.textlength(text, font=font) <= max_width:
+        return text
+
+    ellipsis = "…"
+    low, high = 0, len(text)
+    while low < high:
+        mid = (low + high + 1) // 2
+        candidate = text[:mid].rstrip() + ellipsis
+        if draw.textlength(candidate, font=font) <= max_width:
+            low = mid
+        else:
+            high = mid - 1
+    return text[:low].rstrip() + ellipsis
+
+
+def _center_x(width: int, object_w: int) -> int:
+    return max(0, (width - object_w) // 2)
+
+
+def render_image(
+    output_path: Path,
+    background_path: Path,
+    icon_path: Path,
+    events: Iterable[CalendarEvent],
+    message: str | None = None,
+) -> None:
+    if not background_path.exists():
+        raise FileNotFoundError(f"BACKGROUND_IMAGE not found: {background_path}")
+
+    bg = Image.open(background_path).convert("RGBA").resize((CANVAS_WIDTH, CANVAS_HEIGHT), Image.Resampling.LANCZOS)
+    draw = ImageDraw.Draw(bg)
+
+    font_date = load_font(18)
+    font_title = load_font(14)
+    font_empty = load_font(20)
+    font_more = load_font(13)
+
+    if message:
+        tw = int(draw.textlength(message, font=font_empty))
+        _, ttop, _, tbottom = draw.textbbox((0, 0), message, font=font_empty)
+        th = tbottom - ttop
+        x = _center_x(CANVAS_WIDTH, tw)
+        y = (CANVAS_HEIGHT // 2) - (th // 2) + 34
+        draw.text((x, y), message, fill=(185, 187, 191, 255), font=font_empty)
+    else:
+        entries = list(events)
+
+        icon = None
+        if icon_path.exists():
+            icon = Image.open(icon_path).convert("RGBA").resize((25, 25), Image.Resampling.LANCZOS)
+        else:
+            logging.warning("ICON_IMAGE not found at %s; drawing without icon", icon_path)
+
+        box_x = 25
+        box_w = CANVAS_WIDTH - (box_x * 2)
+        box_h = 38
+        gap = 6
+        first_box_y = 82
+        max_rows = (CANVAS_HEIGHT - first_box_y) // (box_h + gap)
+        if max_rows < 1:
+            max_rows = 1
+
+        visible_events = entries[:max_rows]
+        hidden_count = max(0, len(entries) - len(visible_events))
+
+        for idx, event in enumerate(visible_events):
+            y = first_box_y + idx * (box_h + gap)
+            fill = (7, 7, 7, 235) if not event.all_day else (24, 24, 24, 235)
+            outline = (183, 186, 191, 255)
+            draw.rounded_rectangle(
+                [box_x, y, box_x + box_w, y + box_h],
+                radius=8,
+                fill=fill,
+                outline=outline,
+                width=3,
+            )
+
+            icon_x = box_x + 12
+            icon_y = y + (box_h - 25) // 2
+            if icon:
+                bg.alpha_composite(icon, dest=(icon_x, icon_y))
+
+            date_x = icon_x + 34
+            date_y = y + 8
+            draw.text((date_x, date_y), event.display_date, font=font_date, fill=(196, 198, 202, 255))
+
+            summary_x = date_x + 82
+            summary_y = y + 12
+            max_summary_w = (box_x + box_w - 10) - summary_x
+            clipped_summary = truncate_text(draw, event.summary, font_title, max_summary_w)
+            draw.text((summary_x, summary_y), clipped_summary, font=font_title, fill=(196, 198, 202, 255))
+
+        if hidden_count > 0:
+            more_text = "and more."
+            tw = int(draw.textlength(more_text, font=font_more))
+            draw.text((_center_x(CANVAS_WIDTH, tw), CANVAS_HEIGHT - 16), more_text, font=font_more, fill=(190, 190, 190, 255))
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    if output_path.exists():
+        output_path.unlink()
+
+    bg.convert("RGB").save(output_path, format="PNG")
+    logging.info("Wrote image: %s", output_path)
+
+
+def main() -> int:
+    configure_logging()
+    load_dotenv()
+
+    try:
+        client_id = required_env("GOOGLE_CLIENT_ID")
+        client_secret = required_env("GOOGLE_CLIENT_SECRET")
+        calendar_id = required_env("GOOGLE_CALENDAR_ID")
+        tz_name = required_env("TIMEZONE")
+        output_path = expand_path(required_env("OUTPUT_PATH"))
+        background_path = expand_path(required_env("BACKGROUND_IMAGE"))
+        icon_path = expand_path(required_env("ICON_IMAGE"))
+    except Exception as exc:
+        logging.error("Configuration error: %s", exc)
+        return 1
+
+    try:
+        creds = get_credentials(client_id, client_secret, TOKEN_PATH)
+        service = build("calendar", "v3", credentials=creds, cache_discovery=False)
+        events = fetch_events(service, calendar_id=calendar_id, tz_name=tz_name, retries=3)
+
+        if not events:
+            render_image(
+                output_path=output_path,
+                background_path=background_path,
+                icon_path=icon_path,
+                events=[],
+                message="No upcoming events",
+            )
+        else:
+            render_image(
+                output_path=output_path,
+                background_path=background_path,
+                icon_path=icon_path,
+                events=events,
+            )
+        return 0
+    except Exception as exc:
+        logging.error("Calendar update failed: %s", exc)
+        try:
+            render_image(
+                output_path=output_path,
+                background_path=background_path,
+                icon_path=icon_path,
+                events=[],
+                message="Failed to update calendar",
+            )
+            return 2
+        except Exception as render_exc:
+            logging.error("Also failed rendering error image: %s", render_exc)
+            return 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- Provide a new dashboard page that generates a 320×240 PNG summary of upcoming Google Calendar events for the TFT rotator. 
- Make it easy to configure OAuth, output paths and assets via the repository `.env` and document usage in `README.md`.

### Description

- Add `scripts/calendash-api.py`, a standalone script that authenticates with Google Calendar using OAuth2, fetches events for today through +3 days, and renders a 320×240 PNG using `Pillow` with truncation, per-row icons, and a fallback message or error image. 
- Add Google Calendar configuration variables to `.env.example` (`GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_CALENDAR_ID`, `OUTPUT_PATH`, `BACKGROUND_IMAGE`, `ICON_IMAGE`, `TIMEZONE`).
- Extend `README.md` with installation steps, required Python dependencies, configuration guidance, first-run OAuth instructions, and a recommended daily cron example. 
- The script includes retries with exponential backoff for API/network errors, secure token saving to `token.json` with `0600` permissions, basic font fallback, and robust path handling.

### Testing

- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a39e0e213c8320b0d0f6710614e2e1)