### PR TITLE
Modernize Calendash OAuth fallback away from OOB flow

### DIFF
--- a/scripts/calendash-api.py
+++ b/scripts/calendash-api.py
@@ -78,13 +78,14 @@ def load_font(preferred_size: int) -> ImageFont.FreeTypeFont | ImageFont.ImageFo
 
 
 def build_client_config(client_id: str, client_secret: str) -> dict[str, Any]:
+    oauth_port = int(os.getenv("GOOGLE_OAUTH_LOCAL_PORT", "8080"))
     return {
         "installed": {
             "client_id": client_id,
             "client_secret": client_secret,
             "auth_uri": "https://accounts.google.com/o/oauth2/auth",
             "token_uri": "https://oauth2.googleapis.com/token",
-            "redirect_uris": ["http://localhost", "urn:ietf:wg:oauth:2.0:oob"],
+            "redirect_uris": ["http://localhost", f"http://localhost:{oauth_port}/"],
         }
     }
 
@@ -114,11 +115,23 @@ def get_credentials(client_id: str, client_secret: str, token_path: Path) -> Cre
         build_client_config(client_id, client_secret),
         SCOPES,
     )
+    fixed_oauth_port = int(os.getenv("GOOGLE_OAUTH_LOCAL_PORT", "8080"))
     try:
         creds = flow.run_local_server(port=0, open_browser=False)
     except Exception as exc:
-        logging.info("Local server auth failed (%s); falling back to console flow.", exc)
-        creds = flow.run_console()
+        logging.warning(
+            "OAuth local callback on a random port failed (%s). Retrying on fixed port %d.",
+            exc,
+            fixed_oauth_port,
+        )
+        try:
+            creds = flow.run_local_server(port=fixed_oauth_port, open_browser=False)
+        except Exception as fixed_port_exc:
+            raise RuntimeError(
+                "OAuth setup failed. Ensure GOOGLE_CLIENT_ID/GOOGLE_CLIENT_SECRET belong to a Google OAuth "
+                "Desktop app client and that Authorized redirect URIs include http://localhost and "
+                f"http://localhost:{fixed_oauth_port}/ in Google Cloud Console."
+            ) from fixed_port_exc
     save_credentials(creds, token_path)
     return creds
 


### PR DESCRIPTION
### Motivation
- The previous code fell back to the deprecated out-of-band console flow (`run_console`) when local-server auth failed, which is no longer recommended or supported by Google.
- The change aims to provide a supported, actionable fallback and clearer guidance for operators to configure OAuth clients and redirect URIs.
- Make redirect URIs and retry behavior configurable so installations on headless devices can align the OAuth callback port with Google Cloud Console settings.

### Description
- Replaced the `run_console()` fallback in `get_credentials` with a retry of `flow.run_local_server()` on a fixed port configurable via the `GOOGLE_OAUTH_LOCAL_PORT` environment variable (default `8080`), and raise a clear `RuntimeError` when both attempts fail.
- Updated `build_client_config` to remove the OOB redirect URI `urn:ietf:wg:oauth:2.0:oob` and include a localhost redirect that incorporates `GOOGLE_OAUTH_LOCAL_PORT` so the client config matches the retry port.
- Improved logging and error messaging to instruct operators to use a Google OAuth "Desktop app" client for `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET` and to add `http://localhost` and `http://localhost:<port>/` to the Authorized redirect URIs in Google Cloud Console.

### Testing
- Compiled the modified script with `python3 -m py_compile scripts/calendash-api.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3e9a48024832096b895fdc0f5eb37)