### PR TITLE
Add configurable Calendash font selection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,9 @@ OUTPUT_PATH=~/zero2dash/images/calendash.png
 BACKGROUND_IMAGE=~/zero2dash/images/calendash-bkg.png
 # Event row icon image (small, transparent PNG preferred).
 ICON_IMAGE=~/zero2dash/images/calendash-icon.png
+# Optional comma-separated font files for event text (first existing path is used).
+# Example: CALENDASH_FONT_PATH=/usr/share/fonts/truetype/noto/NotoSans-Regular.ttf,/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf
+CALENDASH_FONT_PATH=
 # Local timezone used for date window and formatting.
 TIMEZONE=Europe/London
 # Local OAuth callback port used by first-run login flow.

--- a/README.md
+++ b/README.md
@@ -199,12 +199,14 @@ python3 -m pip install google-api-python-client google-auth-oauthlib python-dote
    - `OUTPUT_PATH` (recommended: `~/zero2dash/images/calendash.png`)
    - `BACKGROUND_IMAGE`
    - `ICON_IMAGE`
+   - `CALENDASH_FONT_PATH` (optional comma-separated font file paths; first existing path is used)
    - `TIMEZONE` (example: `Europe/London`)
    - `OAUTH_PORT` (optional, default `8080`)
 
 3. Place your assets:
    - `BACKGROUND_IMAGE`: 320×240 background containing the Google Calendar logo/header.
    - `ICON_IMAGE`: small calendar icon used in each event row.
+   - `CALENDASH_FONT_PATH`: optional fallback list to try alternate fonts, e.g. `/usr/share/fonts/truetype/noto/NotoSans-Regular.ttf,/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf`.
 
 ### First run (OAuth)
 

--- a/scripts/calendash-api.py
+++ b/scripts/calendash-api.py
@@ -78,16 +78,28 @@ def optional_env_int(name: str, default: int) -> int:
     return value
 
 
-def load_font(preferred_size: int) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
-    candidates = [
-        "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
-        "/usr/share/fonts/truetype/liberation2/LiberationSans-Bold.ttf",
-        "/usr/share/fonts/truetype/freefont/FreeSansBold.ttf",
-    ]
+def load_font(preferred_size: int, *, use_bold: bool = False) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
+    env_candidates = [p.strip() for p in os.getenv("CALENDASH_FONT_PATH", "").split(",") if p.strip()]
+    if use_bold:
+        default_candidates = [
+            "/usr/share/fonts/truetype/noto/NotoSans-Bold.ttf",
+            "/usr/share/fonts/truetype/liberation2/LiberationSans-Bold.ttf",
+            "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+            "/usr/share/fonts/truetype/freefont/FreeSansBold.ttf",
+        ]
+    else:
+        default_candidates = [
+            "/usr/share/fonts/truetype/noto/NotoSans-Regular.ttf",
+            "/usr/share/fonts/truetype/liberation2/LiberationSans-Regular.ttf",
+            "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+            "/usr/share/fonts/truetype/freefont/FreeSans.ttf",
+        ]
+
+    candidates = env_candidates + default_candidates
     for candidate in candidates:
         if Path(candidate).exists():
             return ImageFont.truetype(candidate, preferred_size)
-    logging.warning("No bold TTF font found; using PIL default font.")
+    logging.warning("No usable TTF font found; using PIL default font.")
     return ImageFont.load_default()
 
 
@@ -270,7 +282,7 @@ def render_image(
     bg = Image.open(background_path).convert("RGBA").resize((CANVAS_WIDTH, CANVAS_HEIGHT), Image.Resampling.LANCZOS)
     draw = ImageDraw.Draw(bg)
 
-    font_date = load_font(18)
+    font_date = load_font(18, use_bold=True)
     font_title = load_font(14)
     font_empty = load_font(20)
     font_more = load_font(13)


### PR DESCRIPTION
## Summary
- updated `scripts/calendash-api.py` to support configurable font overrides via `CALENDASH_FONT_PATH`
- changed default font fallback order to prefer cleaner regular-weight sans fonts for event titles/messages and bold only for dates
- improved font warning text to reflect regular/bold fallback behavior
- documented `CALENDASH_FONT_PATH` in `.env.example` and README configuration docs

## Validation
- `python3 -m py_compile scripts/calendash-api.py`

## Usage
Set in `.env` if you want to force specific fonts:

`CALENDASH_FONT_PATH=/path/to/Font1.ttf,/path/to/Font2.ttf`

The script will use the first existing path.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4283ac5c8832099785378ec27ddba)