### PR TITLE
Harden photos-shuffle.py: robust fallback and framebuffer writes

### DIFF
--- a/scripts/photos-shuffle.py
+++ b/scripts/photos-shuffle.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""
+photos-shuffle.py
+
+One-shot Google Photos album renderer for a 320x240 framebuffer page.
+
+Requirements (pip): Pillow, python-dotenv, google-auth, google-auth-oauthlib,
+google-api-python-client.
+
+Configuration (.env):
+- Required: GOOGLE_PHOTOS_ALBUM_ID
+- Optional: GOOGLE_CLIENT_SECRETS_PATH, GOOGLE_TOKEN_PATH, FB_DEVICE, WIDTH,
+  HEIGHT, CACHE_DIR, FALLBACK_IMAGE, LOGO_PATH
+
+OAuth setup:
+- Put OAuth client secrets JSON at ~/zero2dash/client_secret.json (or override
+  with GOOGLE_CLIENT_SECRETS_PATH).
+- On first run, if token is missing/invalid and refresh is unavailable, the
+  script starts a local OAuth flow and prints instructions to complete login.
+
+Fallback:
+- Ensure local fallback image exists at ~/zero2dash/images/photos-fallback.png
+  (or override with FALLBACK_IMAGE). If online/offline fetch fails, fallback is
+  rendered through the same processing pipeline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from dotenv import load_dotenv
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+from googleapiclient.discovery import build
+from PIL import Image, ImageEnhance
+
+SCOPES = ["https://www.googleapis.com/auth/photoslibrary.readonly"]
+DEFAULT_ROOT = Path("~/zero2dash").expanduser()
+TEST_OUTPUT = Path("/tmp/photos-shuffle-test.png")
+LOGO_WIDTH_RATIO = 0.14
+LOGO_PADDING_RATIO = 0.03
+BRIGHTNESS_FACTOR = 0.75
+
+
+@dataclass
+class Config:
+    album_id: str
+    client_secrets_path: Path
+    token_path: Path
+    fb_device: str
+    width: int
+    height: int
+    cache_dir: Path
+    fallback_image: Path
+    logo_path: Path
+    oauth_port: int
+
+
+class Log:
+    def __init__(self, debug: bool = False) -> None:
+        self.debug_enabled = debug
+
+    def info(self, message: str) -> None:
+        print(message)
+
+    def debug(self, message: str) -> None:
+        if self.debug_enabled:
+            print(f"[debug] {message}")
+
+
+def load_config() -> Config:
+    load_dotenv(DEFAULT_ROOT / ".env")
+
+    album_id = os.getenv("GOOGLE_PHOTOS_ALBUM_ID", "").strip()
+    if not album_id:
+        raise ValueError("GOOGLE_PHOTOS_ALBUM_ID is required in .env")
+
+    def env_path(name: str, default: Path) -> Path:
+        return Path(os.getenv(name, str(default))).expanduser()
+
+    width = int(os.getenv("WIDTH", "320"))
+    height = int(os.getenv("HEIGHT", "240"))
+    return Config(
+        album_id=album_id,
+        client_secrets_path=env_path("GOOGLE_CLIENT_SECRETS_PATH", DEFAULT_ROOT / "client_secret.json"),
+        token_path=env_path("GOOGLE_TOKEN_PATH", DEFAULT_ROOT / "token.json"),
+        fb_device=os.getenv("FB_DEVICE", "/dev/fb1"),
+        width=width,
+        height=height,
+        cache_dir=env_path("CACHE_DIR", DEFAULT_ROOT / "cache" / "google_photos"),
+        fallback_image=env_path("FALLBACK_IMAGE", DEFAULT_ROOT / "images" / "photos-fallback.png"),
+        logo_path=env_path("LOGO_PATH", Path("/images/goo-photos-icon.png")),
+        oauth_port=int(os.getenv("OAUTH_PORT", "8080")),
+    )
+
+
+def authenticate(config: Config, log: Log) -> Credentials:
+    creds: Credentials | None = None
+
+    if config.token_path.exists():
+        creds = Credentials.from_authorized_user_file(str(config.token_path), SCOPES)
+
+    if creds and creds.valid:
+        return creds
+
+    if creds and creds.expired and creds.refresh_token:
+        log.debug("Refreshing existing Google OAuth token")
+        creds.refresh(Request())
+    else:
+        if not config.client_secrets_path.exists():
+            raise FileNotFoundError(f"Client secret not found: {config.client_secrets_path}")
+        log.info("No valid Google token found; starting OAuth local server flow.")
+        log.info(
+            "Follow the browser prompt to authorize Google Photos access, then return to this terminal."
+        )
+        flow = InstalledAppFlow.from_client_secrets_file(str(config.client_secrets_path), SCOPES)
+        creds = flow.run_local_server(port=config.oauth_port, prompt="consent", authorization_prompt_message="")
+
+    config.token_path.parent.mkdir(parents=True, exist_ok=True)
+    config.token_path.write_text(creds.to_json(), encoding="utf-8")
+    log.debug(f"Saved OAuth token to {config.token_path}")
+    return creds
+
+
+def list_album_images(creds: Credentials, album_id: str, log: Log) -> list[dict[str, Any]]:
+    service = build("photoslibrary", "v1", credentials=creds, cache_discovery=False)
+
+    page_token: str | None = None
+    images: list[dict[str, Any]] = []
+
+    while True:
+        body: dict[str, Any] = {"albumId": album_id, "pageSize": 100}
+        if page_token:
+            body["pageToken"] = page_token
+
+        response = service.albums().mediaItems().search(body=body).execute()
+        for item in response.get("mediaItems", []):
+            mime = (item.get("mimeType") or "").lower()
+            if mime.startswith("image/"):
+                images.append(item)
+
+        page_token = response.get("nextPageToken")
+        if not page_token:
+            break
+
+    log.debug(f"Album returned {len(images)} image media items")
+    return images
+
+
+def extension_for_item(item: dict[str, Any]) -> str:
+    mime = (item.get("mimeType") or "").lower()
+    if mime == "image/png":
+        return ".png"
+    if mime == "image/webp":
+        return ".webp"
+    return ".jpg"
+
+
+def cache_path_for_item(cache_dir: Path, item: dict[str, Any]) -> Path:
+    media_id = (item.get("id") or "unknown").strip().replace("/", "_")
+    return cache_dir / f"{media_id}{extension_for_item(item)}"
+
+
+def download_to_cache(creds: Credentials, item: dict[str, Any], cache_path: Path, config: Config, log: Log) -> None:
+    base_url = item.get("baseUrl")
+    if not base_url:
+        raise ValueError("mediaItem missing baseUrl")
+
+    sized_url = f"{base_url}=w{config.width * 2}-h{config.height * 2}"
+    from urllib.request import Request as UrlRequest, urlopen
+
+    req = UrlRequest(sized_url, headers={"Authorization": f"Bearer {creds.token}"})
+    with urlopen(req, timeout=20) as resp:  # nosec B310
+        data = resp.read()
+
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_bytes(data)
+    log.debug(f"Cached image: {cache_path}")
+
+
+def list_cached_images(cache_dir: Path) -> list[Path]:
+    if not cache_dir.exists():
+        return []
+    allowed = {".jpg", ".jpeg", ".png", ".webp"}
+    return [p for p in cache_dir.iterdir() if p.is_file() and p.suffix.lower() in allowed]
+
+
+def center_crop_fill(img: Image.Image, width: int, height: int) -> Image.Image:
+    src_w, src_h = img.size
+    scale = max(width / src_w, height / src_h)
+    resized = img.resize((max(1, int(src_w * scale)), max(1, int(src_h * scale))), Image.Resampling.LANCZOS)
+
+    left = (resized.width - width) // 2
+    top = (resized.height - height) // 2
+    return resized.crop((left, top, left + width, top + height))
+
+
+def composite_frame(photo_path: Path, logo_path: Path, width: int, height: int) -> Image.Image:
+    with Image.open(photo_path) as raw_photo:
+        photo = center_crop_fill(raw_photo.convert("RGB"), width, height)
+
+    photo = ImageEnhance.Brightness(photo).enhance(BRIGHTNESS_FACTOR)
+
+    if logo_path.exists():
+        with Image.open(logo_path) as logo_raw:
+            logo = logo_raw.convert("RGBA")
+            logo_width = max(1, int(width * LOGO_WIDTH_RATIO))
+            logo_height = max(1, int(logo.height * (logo_width / max(1, logo.width))))
+            logo = logo.resize((logo_width, logo_height), Image.Resampling.LANCZOS)
+
+            padding = max(1, int(width * LOGO_PADDING_RATIO))
+            x = max(0, width - logo.width - padding)
+            y = padding
+
+            frame = photo.convert("RGBA")
+            frame.alpha_composite(logo, (x, y))
+            return frame.convert("RGB")
+
+    return photo
+
+
+def rgb888_to_rgb565_bytes(img: Image.Image) -> bytes:
+    rgb = img.convert("RGB").tobytes()
+    out = bytearray((len(rgb) // 3) * 2)
+    j = 0
+    for i in range(0, len(rgb), 3):
+        r = rgb[i]
+        g = rgb[i + 1]
+        b = rgb[i + 2]
+        value = ((r & 0xF8) << 8) | ((g & 0xFC) << 3) | (b >> 3)
+        out[j] = value & 0xFF
+        out[j + 1] = (value >> 8) & 0xFF
+        j += 2
+    return bytes(out)
+
+
+def write_framebuffer(img: Image.Image, fb_device: str, width: int, height: int) -> None:
+    payload = rgb888_to_rgb565_bytes(img)
+    expected = width * height * 2
+    if len(payload) != expected:
+        raise ValueError(f"RGB565 payload size mismatch: {len(payload)} != {expected}")
+
+    with open(fb_device, "r+b", buffering=0) as fb:
+        fb.seek(0)
+        fb.write(payload)
+
+
+def choose_online_image(config: Config, log: Log) -> Path:
+    creds = authenticate(config, log)
+    items = list_album_images(creds, config.album_id, log)
+    if not items:
+        raise RuntimeError("No image media items found in album")
+
+    random.shuffle(items)
+    for item in items:
+        media_id = item.get("id", "unknown")
+        cache_path = cache_path_for_item(config.cache_dir, item)
+        if cache_path.exists() and cache_path.stat().st_size > 0:
+            log.info(f"ONLINE: cache hit for {media_id}")
+            return cache_path
+
+        log.info(f"ONLINE: cache miss for {media_id}; downloading")
+        try:
+            download_to_cache(creds, item, cache_path, config, log)
+            return cache_path
+        except Exception as exc:
+            log.debug(f"Download failed for {media_id}: {exc}")
+            continue
+
+    raise RuntimeError("Unable to fetch any album image")
+
+
+def choose_offline_image(config: Config, log: Log) -> Path:
+    cached = list_cached_images(config.cache_dir)
+    if not cached:
+        raise RuntimeError("Offline cache empty")
+    chosen = random.choice(cached)
+    log.info(f"OFFLINE: selected cached image {chosen.name}")
+    return chosen
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Render one random Google Photos album image to framebuffer.")
+    parser.add_argument("--test", action="store_true", help="Render to /tmp/photos-shuffle-test.png instead of framebuffer")
+    parser.add_argument("--debug", action="store_true", help="Enable verbose debug logs")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    log = Log(debug=args.debug)
+
+    try:
+        config = load_config()
+    except Exception as exc:
+        print(f"Config error: {exc}")
+        return 1
+
+    source_image: Path | None = None
+    try:
+        source_image = choose_online_image(config, log)
+    except Exception as exc:
+        log.info(f"Online unavailable ({exc}); trying offline cache")
+        try:
+            source_image = choose_offline_image(config, log)
+        except Exception as off_exc:
+            log.info(f"Offline cache unavailable ({off_exc}); using fallback image")
+            source_image = config.fallback_image
+
+    try:
+        frame = composite_frame(source_image, config.logo_path, config.width, config.height)
+    except Exception as exc:
+        log.info(f"Primary render failed ({exc}); trying fallback image")
+        try:
+            frame = composite_frame(config.fallback_image, config.logo_path, config.width, config.height)
+        except Exception as fallback_exc:
+            print(f"Unable to render fallback image: {fallback_exc}")
+            return 1
+
+    if args.test:
+        frame.save(TEST_OUTPUT)
+        log.info(f"Rendered test image: {TEST_OUTPUT}")
+        return 0
+
+    try:
+        write_framebuffer(frame, config.fb_device, config.width, config.height)
+        log.info(f"Rendered one frame to {config.fb_device}")
+        return 0
+    except Exception as exc:
+        log.info(f"Framebuffer write failed ({exc}); trying fallback framebuffer render")
+        try:
+            fallback_frame = composite_frame(config.fallback_image, config.logo_path, config.width, config.height)
+            write_framebuffer(fallback_frame, config.fb_device, config.width, config.height)
+            log.info(f"Rendered fallback frame to {config.fb_device}")
+            return 0
+        except Exception as fallback_exc:
+            print(f"Unable to render to framebuffer: {fallback_exc}")
+            return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Provide a one-shot page script that fetches a random image from a Google Photos album, caches it, and renders exactly one frame to a 320×240 framebuffer while falling back to cached or local images when online fetches fail.
- Make the rendering path robust against unexpected API/network/framebuffer errors so the page reliably falls back instead of aborting.

### Description
- Add `scripts/photos-shuffle.py` which loads configuration from `~/zero2dash/.env`, performs Google Photos OAuth (local server flow when needed), lists album image media, caches downloaded images under `CACHE_DIR`, and selects one random image for rendering; includes `--test` and `--debug` CLI flags.
- Implement the rendering pipeline that center-crops to `WIDTH×HEIGHT`, dims the photo by factor `0.75`, overlays the PNG at `LOGO_PATH` (alpha preserved, top-right), converts the final image to RGB565 little-endian, and writes a single frame to `FB_DEVICE`. 
- Harden fallback/error handling by broadening the online-path exception handling in `main()` to `except Exception` so any unexpected runtime/API error falls through to offline cache or the configured fallback image.
- Ensure safer framebuffer writes by rewinding the device with `fb.seek(0)` before writing the RGB565 payload, and remove now-unused Google API exception imports.

### Testing
- Performed a syntax check with `python3 -m py_compile scripts/photos-shuffle.py`, which succeeded.
- Validated the file parses with Python's `ast` module, which succeeded.
- No full runtime/integration tests were executed here because required runtime packages and a real framebuffer device were not exercised in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a43ce41ae8832085d869961b0b4396)