### PR TITLE
Separate Google OAuth tokens per script and validate token scopes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,8 @@ CALENDASH_FONT_PATH=
 TIMEZONE=Europe/London
 # Local OAuth callback port used by first-run login flow.
 OAUTH_PORT=8080
+# Optional calendar token path (keep separate from photos token).
+GOOGLE_TOKEN_PATH=~/zero2dash/token.json
 
 # --- Pi-hole dashboard settings (existing scripts) ---
 # Pi-hole API endpoint (hostname or IP, with or without http://)
@@ -34,3 +36,13 @@ PIHOLE_API_TOKEN=
 REFRESH_SECS=3
 # ACTIVE_HOURS as start,end (24h) e.g. 22,7
 ACTIVE_HOURS=22,7
+
+# --- Google Photos (photos-shuffle.py) ---
+# Album ID to pull shuffled photos from.
+GOOGLE_PHOTOS_ALBUM_ID=replace-with-google-photos-album-id
+# Optional OAuth client secrets json path for Photos flow.
+GOOGLE_CLIENT_SECRETS_PATH=~/zero2dash/client_secret.json
+# Photos token path MUST be separate from calendash token.json.
+GOOGLE_TOKEN_PATH_PHOTOS=~/zero2dash/token_photos.json
+# Optional: auto-open browser during OAuth (1=true, 0=false).
+OAUTH_OPEN_BROWSER=0

--- a/README.md
+++ b/README.md
@@ -224,6 +224,16 @@ python3 scripts/calendash-api.py
 
 After first auth, future runs refresh tokens automatically and are suitable for headless cron execution.
 
+
+### Token separation (important)
+
+Use separate OAuth token files per script to avoid scope conflicts:
+
+- `scripts/calendash-api.py` (Calendar): `GOOGLE_TOKEN_PATH` (default `token.json`)
+- `scripts/photos-shuffle.py` (Photos): `GOOGLE_TOKEN_PATH_PHOTOS` (default `~/zero2dash/token_photos.json`)
+
+Do **not** point the Photos script at `token.json`. The Photos script now blocks that configuration and asks for a separate token path.
+
 ### OAuth troubleshooting (`localhost` connection refused after clicking **Continue**)
 
 If Google sign-in works but the final redirect page fails with `localhost refused to connect`, the browser and `calendash-api.py` are usually not on the same network namespace.

--- a/scripts/calendash-api.py
+++ b/scripts/calendash-api.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import logging
 import os
 import time
+import json
 from dataclasses import dataclass
 from datetime import date, datetime, time as dt_time, timedelta
 from pathlib import Path
@@ -34,8 +35,24 @@ from PIL import Image, ImageDraw, ImageFont
 SCOPES = ["https://www.googleapis.com/auth/calendar.readonly"]
 CANVAS_WIDTH = 320
 CANVAS_HEIGHT = 240
-TOKEN_PATH = Path("token.json")
+DEFAULT_TOKEN_PATH = Path("token.json")
 DEFAULT_OAUTH_PORT = 8080
+
+
+def _normalize_scopes(raw_scopes: Any) -> set[str]:
+    if isinstance(raw_scopes, str):
+        return {raw_scopes}
+    if isinstance(raw_scopes, (list, tuple, set)):
+        return {str(scope) for scope in raw_scopes if scope}
+    return set()
+
+
+def _is_token_compatible_with_calendar(token_payload: dict[str, Any]) -> bool:
+    token_scopes = _normalize_scopes(token_payload.get("scopes") or token_payload.get("scope"))
+    if not token_scopes:
+        # Older token files may not include explicit scopes; let google-auth decide.
+        return True
+    return set(SCOPES).issubset(token_scopes)
 
 
 @dataclass
@@ -139,7 +156,22 @@ def get_credentials(client_id: str, client_secret: str, token_path: Path, oauth_
     creds: Credentials | None = None
 
     if token_path.exists():
-        creds = Credentials.from_authorized_user_file(str(token_path), SCOPES)
+        try:
+            payload = json.loads(token_path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            logging.warning("Ignoring invalid token file at %s (%s).", token_path.resolve(), exc)
+            payload = None
+
+        if payload and not _is_token_compatible_with_calendar(payload):
+            logging.warning(
+                "Token at %s does not include calendar scope; re-authenticating.",
+                token_path.resolve(),
+            )
+        else:
+            try:
+                creds = Credentials.from_authorized_user_file(str(token_path), SCOPES)
+            except Exception as exc:
+                logging.warning("Unable to load token from %s (%s); re-authenticating.", token_path.resolve(), exc)
 
     if creds and creds.valid:
         return creds
@@ -368,12 +400,13 @@ def main() -> int:
         background_path = expand_path(required_env("BACKGROUND_IMAGE"))
         icon_path = expand_path(required_env("ICON_IMAGE"))
         oauth_port = optional_env_int("OAUTH_PORT", DEFAULT_OAUTH_PORT)
+        token_path = expand_path(os.getenv("GOOGLE_TOKEN_PATH", str(DEFAULT_TOKEN_PATH)))
     except Exception as exc:
         logging.error("Configuration error: %s", exc)
         return 1
 
     try:
-        creds = get_credentials(client_id, client_secret, TOKEN_PATH, oauth_port)
+        creds = get_credentials(client_id, client_secret, token_path, oauth_port)
         service = build("calendar", "v3", credentials=creds, cache_discovery=False)
         events = fetch_events(service, calendar_id=calendar_id, tz_name=tz_name, retries=3)
 
@@ -405,7 +438,7 @@ def main() -> int:
             )
             return 2
         except Exception as render_exc:
-            logging.error("Also failed rendering error image: %s", render_exc)
+            logging.error("Failed to render fallback image: %s", render_exc)
             return 3
 
 

--- a/scripts/photos-shuffle.py
+++ b/scripts/photos-shuffle.py
@@ -9,7 +9,7 @@ google-api-python-client.
 
 Configuration (.env):
 - Required: GOOGLE_PHOTOS_ALBUM_ID
-- Optional: GOOGLE_CLIENT_SECRETS_PATH, GOOGLE_TOKEN_PATH, FB_DEVICE, WIDTH,
+- Optional: GOOGLE_CLIENT_SECRETS_PATH, GOOGLE_TOKEN_PATH_PHOTOS, FB_DEVICE, WIDTH,
   HEIGHT, CACHE_DIR, FALLBACK_IMAGE, LOGO_PATH
 - Optional OAuth alternative: GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET
   (used when GOOGLE_CLIENT_SECRETS_PATH file is not present).
@@ -19,7 +19,7 @@ OAuth setup:
   with GOOGLE_CLIENT_SECRETS_PATH).
 - Token path defaults to ~/zero2dash/token_photos.json so it does not
   conflict with calendar scripts that use token.json (override with
-  GOOGLE_TOKEN_PATH if needed).
+  GOOGLE_TOKEN_PATH_PHOTOS if needed).
 - On first run, if token is missing/invalid and refresh is unavailable, the
   script starts a local OAuth flow and prints instructions to complete login.
 - In headless environments, it does not auto-launch a browser by default;
@@ -34,6 +34,7 @@ Fallback:
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import random
 from dataclasses import dataclass
@@ -72,6 +73,21 @@ class Config:
     oauth_open_browser: bool
 
 
+def _normalize_scopes(raw_scopes: Any) -> set[str]:
+    if isinstance(raw_scopes, str):
+        return {raw_scopes}
+    if isinstance(raw_scopes, (list, tuple, set)):
+        return {str(scope) for scope in raw_scopes if scope}
+    return set()
+
+
+def _is_token_compatible_with_photos(token_payload: dict[str, Any]) -> bool:
+    token_scopes = _normalize_scopes(token_payload.get("scopes") or token_payload.get("scope"))
+    if not token_scopes:
+        return True
+    return set(SCOPES).issubset(token_scopes)
+
+
 class Log:
     def __init__(self, debug: bool = False) -> None:
         self.debug_enabled = debug
@@ -103,7 +119,10 @@ def load_config() -> Config:
         client_secrets_path=env_path("GOOGLE_CLIENT_SECRETS_PATH", DEFAULT_ROOT / "client_secret.json"),
         client_id=os.getenv("GOOGLE_CLIENT_ID", "").strip(),
         client_secret=os.getenv("GOOGLE_CLIENT_SECRET", "").strip(),
-        token_path=env_path("GOOGLE_TOKEN_PATH", DEFAULT_ROOT / "token_photos.json"),
+        token_path=env_path(
+            "GOOGLE_TOKEN_PATH_PHOTOS",
+            env_path("GOOGLE_TOKEN_PATH", DEFAULT_ROOT / "token_photos.json"),
+        ),
         fb_device=os.getenv("FB_DEVICE", "/dev/fb1"),
         width=width,
         height=height,
@@ -118,12 +137,30 @@ def load_config() -> Config:
 def authenticate(config: Config, log: Log) -> Credentials:
     creds: Credentials | None = None
 
+    calendar_default_token = (DEFAULT_ROOT / "token.json").resolve()
+    if config.token_path.resolve() == calendar_default_token:
+        raise ValueError(
+            "GOOGLE_TOKEN_PATH points to token.json, which is reserved for calendash-api.py. "
+            "Use a separate photos token path (default: ~/zero2dash/token_photos.json)."
+        )
+
     if config.token_path.exists():
         try:
-            creds = Credentials.from_authorized_user_file(str(config.token_path), SCOPES)
+            payload = json.loads(config.token_path.read_text(encoding="utf-8"))
         except Exception as exc:
             log.info(f"Existing token at {config.token_path} is invalid ({exc}); re-authenticating")
-            creds = None
+            payload = None
+
+        if payload and not _is_token_compatible_with_photos(payload):
+            log.info(
+                f"Token at {config.token_path} does not include Google Photos scope; re-authenticating"
+            )
+        else:
+            try:
+                creds = Credentials.from_authorized_user_file(str(config.token_path), SCOPES)
+            except Exception as exc:
+                log.info(f"Existing token at {config.token_path} is invalid ({exc}); re-authenticating")
+                creds = None
 
     if creds and creds.valid:
         return creds
@@ -163,7 +200,7 @@ def authenticate(config: Config, log: Log) -> Credentials:
         creds = flow.run_local_server(
             port=config.oauth_port,
             prompt="consent",
-            authorization_prompt_message="",
+            authorization_prompt_message="Open this URL in your browser to authorize Google Photos access: {url}",
             open_browser=config.oauth_open_browser,
         )
 


### PR DESCRIPTION
### Motivation

- Avoid token scope conflicts between the Calendar and Photos scripts by letting each script use its own OAuth token path and by detecting incompatible token files.
- Improve robustness when loading existing token files by handling invalid JSON and providing clearer re-authentication logging.
- Update environment examples and README to document the new token variables and warn users not to reuse `token.json` for Photos.

### Description

- Introduced `GOOGLE_TOKEN_PATH` support in `scripts/calendash-api.py` (default `token.json`) and replaced the module-level `TOKEN_PATH` with `DEFAULT_TOKEN_PATH` and runtime `token_path` resolution via `os.getenv`.
- Added JSON-based token payload inspection and scope compatibility checks in both `calendash-api.py` and `photos-shuffle.py` via helper functions `_normalize_scopes` and `_is_token_compatible_with_*` to force re-auth when scopes are missing or insufficient.
- In `photos-shuffle.py`, switched to prefer `GOOGLE_TOKEN_PATH_PHOTOS` (falling back to `GOOGLE_TOKEN_PATH` then default) and added a guard that refuses to use the calendar default `token.json`, raising an explicit error to prevent scope collisions.
- Improved error/log messages around token loading, invalid token files, refresh attempts, and the OAuth prompt; adjusted the `InstalledAppFlow` prompt message for Photos and ensured token files are written with `creds.to_json()`.
- Updated `.env.example` with `GOOGLE_TOKEN_PATH`, Photos-specific settings (`GOOGLE_PHOTOS_ALBUM_ID`, `GOOGLE_CLIENT_SECRETS_PATH`, `GOOGLE_TOKEN_PATH_PHOTOS`, `OAUTH_OPEN_BROWSER`) and updated `README.md` to document token separation and the Photos script behavior.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a48493a6808320b4925d4cfafc9b22)