### PR TITLE
Add shared env config helper and --check-config for dashboard scripts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,53 +2,70 @@
 # Never commit real secrets.
 
 # --- Google Calendar (calendash-api.py) ---
-# OAuth2 Desktop client credentials from Google Cloud console.
-GOOGLE_CLIENT_ID=replace-with-google-client-id.apps.googleusercontent.com
-GOOGLE_CLIENT_SECRET=replace-with-google-client-secret
-# Optional dedicated OAuth client for Calendar only (recommended if Photos auth is blocked).
+# Required secret credentials: set either dedicated Calendar creds OR shared Google creds.
+# Required (if GOOGLE_CLIENT_ID is empty):
 GOOGLE_CALENDAR_CLIENT_ID=
+# Required secret (if GOOGLE_CLIENT_SECRET is empty):
 GOOGLE_CALENDAR_CLIENT_SECRET=
-# Use "primary" for your personal primary calendar.
+# Optional fallback shared Google OAuth client ID.
+GOOGLE_CLIENT_ID=
+# Optional fallback shared Google OAuth client secret.
+GOOGLE_CLIENT_SECRET=
+# Required: Calendar ID (use "primary" for your personal calendar).
 GOOGLE_CALENDAR_ID=primary
-# Output PNG path (script deletes old file before writing a new one).
+# Required: Local timezone used for date window and formatting.
+TIMEZONE=Europe/London
+
+# Optional with safe defaults in script:
+# OUTPUT_PATH default: ~/zero2dash/images/calendash.png
 OUTPUT_PATH=~/zero2dash/images/calendash.png
-# 320x240 base background image (contains Calendar logo/header area).
+# BACKGROUND_IMAGE default: ~/zero2dash/images/calendash-bkg.png
 BACKGROUND_IMAGE=~/zero2dash/images/calendash-bkg.png
-# Event row icon image (small, transparent PNG preferred).
+# ICON_IMAGE default: ~/zero2dash/images/calendash-icon.png
 ICON_IMAGE=~/zero2dash/images/calendash-icon.png
 # Optional comma-separated font files for event text (first existing path is used).
-# Example: CALENDASH_FONT_PATH=/usr/share/fonts/truetype/noto/NotoSans-Regular.ttf,/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf
 CALENDASH_FONT_PATH=
-# Local timezone used for date window and formatting.
-TIMEZONE=Europe/London
-# Local OAuth callback port used by first-run login flow.
+# OAUTH_PORT default: 8080
 OAUTH_PORT=8080
-# Optional calendar token path (keep separate from photos token).
+# GOOGLE_TOKEN_PATH default: token.json
 GOOGLE_TOKEN_PATH=~/zero2dash/token.json
 
-# --- Pi-hole dashboard settings (existing scripts) ---
-# Pi-hole API endpoint (hostname or IP, with or without http://)
+# --- Pi-hole dashboards (piholestats_v1.1.py / piholestats_v1.2.py) ---
+# Optional host, default: 127.0.0.1
 PIHOLE_HOST=192.168.1.2
-
-# Pi-hole admin password used for v6 API auth
+# Required secret: Pi-hole admin password for v6 API auth.
 PIHOLE_PASSWORD=replace-with-your-pihole-password
-# Optional legacy API token for /admin/api.php fallback
+# Optional: legacy API token for /admin/api.php fallback.
 PIHOLE_API_TOKEN=
-
-# Optional runtime tuning
+# Optional framebuffer device path, default: /dev/fb1
+FB_DEVICE=/dev/fb1
+# Optional refresh interval seconds, default: 3
 REFRESH_SECS=3
-# ACTIVE_HOURS as start,end (24h) e.g. 22,7
+# Optional active window as start,end in 24h format. Defaults depend on script version.
 ACTIVE_HOURS=22,7
 
 # --- Google Photos (photos-shuffle.py) ---
-# Album ID to pull shuffled photos from.
+# Required: Album ID to pull shuffled photos from.
 GOOGLE_PHOTOS_ALBUM_ID=replace-with-google-photos-album-id
-# Optional OAuth client secrets json path for Photos flow.
+# OAuth credentials are required by one of these methods:
+# 1) Existing client secrets file (default path shown), OR
+# 2) GOOGLE_PHOTOS_CLIENT_ID + GOOGLE_PHOTOS_CLIENT_SECRET values.
 GOOGLE_PHOTOS_CLIENT_SECRETS_PATH=~/zero2dash/client_secret.json
-# Optional dedicated OAuth client creds for Photos only.
 GOOGLE_PHOTOS_CLIENT_ID=
 GOOGLE_PHOTOS_CLIENT_SECRET=
-# Photos token path MUST be separate from calendash token.json.
+
+# Optional with safe defaults in script:
+# GOOGLE_TOKEN_PATH_PHOTOS default: ~/zero2dash/token_photos.json
 GOOGLE_TOKEN_PATH_PHOTOS=~/zero2dash/token_photos.json
-# Optional: auto-open browser during OAuth (1=true, 0=false).
+# WIDTH default: 320
+WIDTH=320
+# HEIGHT default: 240
+HEIGHT=240
+# CACHE_DIR default: ~/zero2dash/cache/google_photos
+CACHE_DIR=~/zero2dash/cache/google_photos
+# FALLBACK_IMAGE default: ~/zero2dash/images/photos-fallback.png
+FALLBACK_IMAGE=~/zero2dash/images/photos-fallback.png
+# LOGO_PATH default: /images/goo-photos-icon.png
+LOGO_PATH=/images/goo-photos-icon.png
+# OAUTH_OPEN_BROWSER default: 0 (false)
 OAUTH_OPEN_BROWSER=0

--- a/scripts/_config.py
+++ b/scripts/_config.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Shared environment/config helpers for dashboard scripts."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Callable
+
+Validator = Callable[[str], Any]
+
+
+def get_env(
+    name: str,
+    default: Any = None,
+    required: bool = False,
+    validator: Validator | None = None,
+) -> Any:
+    """Read and validate an environment variable.
+
+    Args:
+        name: Environment variable name.
+        default: Value returned when env is unset/blank and not required.
+        required: When True, env must be set to a non-empty value.
+        validator: Optional callable to transform/validate the raw string value.
+
+    Raises:
+        ValueError: If required value is missing or validator rejects the value.
+    """
+
+    raw_value = os.getenv(name)
+    if raw_value is None or raw_value.strip() == "":
+        if required:
+            raise ValueError(f"{name} is required but not set.")
+        return default
+
+    value = raw_value.strip()
+    if validator is None:
+        return value
+
+    try:
+        return validator(value)
+    except ValueError as exc:
+        raise ValueError(f"{name} is invalid: {exc}") from exc
+    except Exception as exc:  # defensive: normalize unknown validator errors
+        raise ValueError(f"{name} is invalid: {exc}") from exc
+
+
+def report_validation_errors(script_name: str, errors: list[str]) -> None:
+    """Print a single structured validation report."""
+    print(f"[{script_name}] Configuration check failed ({len(errors)} issue{'s' if len(errors) != 1 else ''}):")
+    for issue in errors:
+        print(f"  - {issue}")

--- a/scripts/calendash-api.py
+++ b/scripts/calendash-api.py
@@ -18,6 +18,7 @@ import logging
 import os
 import time
 import json
+import argparse
 from dataclasses import dataclass
 from datetime import date, datetime, time as dt_time, timedelta
 from pathlib import Path
@@ -31,6 +32,8 @@ from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 from PIL import Image, ImageDraw, ImageFont
+
+from _config import get_env, report_validation_errors
 
 SCOPES = ["https://www.googleapis.com/auth/calendar.readonly"]
 CANVAS_WIDTH = 320
@@ -71,21 +74,6 @@ def configure_logging() -> None:
     )
 
 
-def required_env(name: str) -> str:
-    value = os.getenv(name)
-    if not value:
-        raise ValueError(f"Missing required env variable: {name}")
-    return value
-
-
-def required_env_any(*names: str) -> str:
-    for name in names:
-        value = os.getenv(name, "").strip()
-        if value:
-            return value
-    raise ValueError(f"Missing required env variable: one of {', '.join(names)}")
-
-
 def expand_path(value: str) -> Path:
     return Path(value).expanduser().resolve()
 
@@ -101,6 +89,75 @@ def optional_env_int(name: str, default: int) -> int:
     if value <= 0:
         raise ValueError(f"{name} must be greater than 0")
     return value
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate a calendar summary image.")
+    parser.add_argument("--check-config", action="store_true", help="Validate env configuration and exit")
+    return parser.parse_args()
+
+
+def validate_timezone(value: str) -> str:
+    pytz.timezone(value)
+    return value
+
+
+def validate_config() -> tuple[dict[str, Any] | None, list[str]]:
+    errors: list[str] = []
+
+    def record(name: str, *, default: Any = None, required: bool = False, validator: Any = None) -> Any:
+        try:
+            return get_env(name, default=default, required=required, validator=validator)
+        except ValueError as exc:
+            errors.append(str(exc))
+            return default
+
+    calendar_client_id = record("GOOGLE_CALENDAR_CLIENT_ID")
+    fallback_client_id = record("GOOGLE_CLIENT_ID")
+    client_id = calendar_client_id or fallback_client_id
+    if not client_id:
+        errors.append("One of GOOGLE_CALENDAR_CLIENT_ID or GOOGLE_CLIENT_ID is required but not set.")
+
+    calendar_client_secret = record("GOOGLE_CALENDAR_CLIENT_SECRET")
+    fallback_client_secret = record("GOOGLE_CLIENT_SECRET")
+    client_secret = calendar_client_secret or fallback_client_secret
+    if not client_secret:
+        errors.append("One of GOOGLE_CALENDAR_CLIENT_SECRET or GOOGLE_CLIENT_SECRET is required but not set.")
+
+    calendar_id = record("GOOGLE_CALENDAR_ID", required=True)
+    tz_name = record("TIMEZONE", required=True, validator=validate_timezone)
+
+    output_raw = record("OUTPUT_PATH", default="~/zero2dash/images/calendash.png")
+    background_raw = record("BACKGROUND_IMAGE", default="~/zero2dash/images/calendash-bkg.png")
+    icon_raw = record("ICON_IMAGE", default="~/zero2dash/images/calendash-icon.png")
+
+    oauth_port = record("OAUTH_PORT", default=DEFAULT_OAUTH_PORT, validator=lambda v: optional_env_int("OAUTH_PORT", DEFAULT_OAUTH_PORT))
+    token_raw = record("GOOGLE_TOKEN_PATH", default=str(DEFAULT_TOKEN_PATH))
+
+    output_path = expand_path(str(output_raw))
+    background_path = expand_path(str(background_raw))
+    icon_path = expand_path(str(icon_raw))
+    token_path = expand_path(str(token_raw))
+
+    if not background_path.exists():
+        errors.append(f"BACKGROUND_IMAGE not found: {background_path}")
+    if not icon_path.exists():
+        errors.append(f"ICON_IMAGE not found: {icon_path}")
+
+    if errors:
+        return None, errors
+
+    return {
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "calendar_id": calendar_id,
+        "tz_name": tz_name,
+        "output_path": output_path,
+        "background_path": background_path,
+        "icon_path": icon_path,
+        "oauth_port": int(oauth_port),
+        "token_path": token_path,
+    }, []
 
 
 def load_font(preferred_size: int, *, use_bold: bool = False) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
@@ -404,39 +461,36 @@ def render_image(
 def main() -> int:
     configure_logging()
     load_dotenv()
+    args = parse_args()
 
-    try:
-        client_id = required_env_any("GOOGLE_CALENDAR_CLIENT_ID", "GOOGLE_CLIENT_ID")
-        client_secret = required_env_any("GOOGLE_CALENDAR_CLIENT_SECRET", "GOOGLE_CLIENT_SECRET")
-        calendar_id = required_env("GOOGLE_CALENDAR_ID")
-        tz_name = required_env("TIMEZONE")
-        output_path = expand_path(required_env("OUTPUT_PATH"))
-        background_path = expand_path(required_env("BACKGROUND_IMAGE"))
-        icon_path = expand_path(required_env("ICON_IMAGE"))
-        oauth_port = optional_env_int("OAUTH_PORT", DEFAULT_OAUTH_PORT)
-        token_path = expand_path(os.getenv("GOOGLE_TOKEN_PATH", str(DEFAULT_TOKEN_PATH)))
-    except Exception as exc:
-        logging.error("Configuration error: %s", exc)
+    config, errors = validate_config()
+    if errors:
+        report_validation_errors("calendash-api.py", errors)
         return 1
+    assert config is not None
+
+    if args.check_config:
+        print("[calendash-api.py] Configuration check passed.")
+        return 0
 
     try:
-        creds = get_credentials(client_id, client_secret, token_path, oauth_port)
+        creds = get_credentials(config["client_id"], config["client_secret"], config["token_path"], config["oauth_port"])
         service = build("calendar", "v3", credentials=creds, cache_discovery=False)
-        events = fetch_events(service, calendar_id=calendar_id, tz_name=tz_name, retries=3)
+        events = fetch_events(service, calendar_id=config["calendar_id"], tz_name=config["tz_name"], retries=3)
 
         if not events:
             render_image(
-                output_path=output_path,
-                background_path=background_path,
-                icon_path=icon_path,
+                output_path=config["output_path"],
+                background_path=config["background_path"],
+                icon_path=config["icon_path"],
                 events=[],
                 message="No upcoming events",
             )
         else:
             render_image(
-                output_path=output_path,
-                background_path=background_path,
-                icon_path=icon_path,
+                output_path=config["output_path"],
+                background_path=config["background_path"],
+                icon_path=config["icon_path"],
                 events=events,
             )
         return 0
@@ -444,9 +498,9 @@ def main() -> int:
         logging.error("Calendar update failed: %s", exc)
         try:
             render_image(
-                output_path=output_path,
-                background_path=background_path,
-                icon_path=icon_path,
+                output_path=config["output_path"],
+                background_path=config["background_path"],
+                icon_path=config["icon_path"],
                 events=[],
                 message="Failed to update calendar",
             )

--- a/scripts/photos-shuffle.py
+++ b/scripts/photos-shuffle.py
@@ -41,6 +41,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from _config import get_env, report_validation_errors
+
 from dotenv import load_dotenv
 from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
@@ -100,35 +102,96 @@ class Log:
             print(f"[debug] {message}")
 
 
+def _as_int(name: str, value: str) -> int:
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise ValueError(f"expected integer, got {value!r}") from exc
+
+
+def _as_bool(value: str) -> bool:
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def validate_config() -> tuple[Config | None, list[str]]:
+    errors: list[str] = []
+
+    def record(name: str, *, default: Any = None, required: bool = False, validator: Any = None) -> Any:
+        try:
+            return get_env(name, default=default, required=required, validator=validator)
+        except ValueError as exc:
+            errors.append(str(exc))
+            return default
+
+    album_id = record("GOOGLE_PHOTOS_ALBUM_ID", required=True)
+    client_secrets_raw = record("GOOGLE_PHOTOS_CLIENT_SECRETS_PATH", default=str(DEFAULT_ROOT / "client_secret.json"))
+
+    client_id = record("GOOGLE_PHOTOS_CLIENT_ID") or record("GOOGLE_CLIENT_ID") or ""
+    client_secret = record("GOOGLE_PHOTOS_CLIENT_SECRET") or record("GOOGLE_CLIENT_SECRET") or ""
+
+    token_raw = record("GOOGLE_TOKEN_PATH_PHOTOS", default=str(DEFAULT_ROOT / "token_photos.json"))
+    fb_device = record("FB_DEVICE", default="/dev/fb1")
+    width = record("WIDTH", default=320, validator=lambda v: _as_int("WIDTH", v))
+    height = record("HEIGHT", default=240, validator=lambda v: _as_int("HEIGHT", v))
+    cache_raw = record("CACHE_DIR", default=str(DEFAULT_ROOT / "cache" / "google_photos"))
+    fallback_raw = record("FALLBACK_IMAGE", default=str(DEFAULT_ROOT / "images" / "photos-fallback.png"))
+    logo_raw = record("LOGO_PATH", default="/images/goo-photos-icon.png")
+    oauth_port = record("OAUTH_PORT", default=8080, validator=lambda v: _as_int("OAUTH_PORT", v))
+    oauth_open_browser = record("OAUTH_OPEN_BROWSER", default=False, validator=_as_bool)
+
+    if isinstance(width, int) and width <= 0:
+        errors.append("WIDTH is invalid: must be greater than 0")
+    if isinstance(height, int) and height <= 0:
+        errors.append("HEIGHT is invalid: must be greater than 0")
+    if isinstance(oauth_port, int) and oauth_port <= 0:
+        errors.append("OAUTH_PORT is invalid: must be greater than 0")
+
+    fallback_image = Path(str(fallback_raw)).expanduser()
+    if not fallback_image.exists():
+        errors.append(f"FALLBACK_IMAGE not found: {fallback_image}")
+
+    config = Config(
+        album_id=str(album_id),
+        client_secrets_path=Path(str(client_secrets_raw)).expanduser(),
+        client_id=str(client_id),
+        client_secret=str(client_secret),
+        token_path=Path(str(token_raw)).expanduser(),
+        fb_device=str(fb_device),
+        width=int(width),
+        height=int(height),
+        cache_dir=Path(str(cache_raw)).expanduser(),
+        fallback_image=fallback_image,
+        logo_path=Path(str(logo_raw)).expanduser(),
+        oauth_port=int(oauth_port),
+        oauth_open_browser=bool(oauth_open_browser),
+    )
+
+    calendar_default_token = (DEFAULT_ROOT / "token.json").resolve()
+    if config.token_path.resolve() == calendar_default_token:
+        errors.append(
+            "GOOGLE_TOKEN_PATH_PHOTOS points to token.json, which is reserved for calendash-api.py. "
+            "Use a separate photos token path (default: ~/zero2dash/token_photos.json)."
+        )
+
+    if not config.client_secrets_path.exists() and not (config.client_id and config.client_secret):
+        errors.append(
+            f"Google Photos OAuth credentials are required: set GOOGLE_PHOTOS_CLIENT_SECRETS_PATH to an existing file "
+            f"or provide GOOGLE_PHOTOS_CLIENT_ID + GOOGLE_PHOTOS_CLIENT_SECRET (checked path: {config.client_secrets_path})."
+        )
+
+    if errors:
+        return None, errors
+    return config, []
+
+
 def load_config() -> Config:
     load_dotenv(DEFAULT_ROOT / ".env")
-
-    album_id = os.getenv("GOOGLE_PHOTOS_ALBUM_ID", "").strip()
-    if not album_id:
-        raise ValueError("GOOGLE_PHOTOS_ALBUM_ID is required in .env")
-
-    def env_path(name: str, default: Path) -> Path:
-        return Path(os.getenv(name, str(default))).expanduser()
-
-    width = int(os.getenv("WIDTH", "320"))
-    height = int(os.getenv("HEIGHT", "240"))
-
-    oauth_open_browser = os.getenv("OAUTH_OPEN_BROWSER", "0").strip().lower() in {"1", "true", "yes", "on"}
-    return Config(
-        album_id=album_id,
-        client_secrets_path=env_path("GOOGLE_PHOTOS_CLIENT_SECRETS_PATH", env_path("GOOGLE_CLIENT_SECRETS_PATH", DEFAULT_ROOT / "client_secret.json")),
-        client_id=os.getenv("GOOGLE_PHOTOS_CLIENT_ID", os.getenv("GOOGLE_CLIENT_ID", "")).strip(),
-        client_secret=os.getenv("GOOGLE_PHOTOS_CLIENT_SECRET", os.getenv("GOOGLE_CLIENT_SECRET", "")).strip(),
-        token_path=env_path("GOOGLE_TOKEN_PATH_PHOTOS", DEFAULT_ROOT / "token_photos.json"),
-        fb_device=os.getenv("FB_DEVICE", "/dev/fb1"),
-        width=width,
-        height=height,
-        cache_dir=env_path("CACHE_DIR", DEFAULT_ROOT / "cache" / "google_photos"),
-        fallback_image=env_path("FALLBACK_IMAGE", DEFAULT_ROOT / "images" / "photos-fallback.png"),
-        logo_path=env_path("LOGO_PATH", Path("/images/goo-photos-icon.png")),
-        oauth_port=int(os.getenv("OAUTH_PORT", "8080")),
-        oauth_open_browser=oauth_open_browser,
-    )
+    config, errors = validate_config()
+    if errors:
+        report_validation_errors("photos-shuffle.py", errors)
+        raise ValueError("Invalid configuration")
+    assert config is not None
+    return config
 
 
 def authenticate(config: Config, log: Log) -> Credentials:
@@ -375,6 +438,7 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Render one random Google Photos album image to framebuffer.")
     parser.add_argument("--test", action="store_true", help="Render to /tmp/photos-shuffle-test.png instead of framebuffer")
     parser.add_argument("--debug", action="store_true", help="Enable verbose debug logs")
+    parser.add_argument("--check-config", action="store_true", help="Validate env configuration and exit")
     return parser.parse_args()
 
 
@@ -382,11 +446,16 @@ def main() -> int:
     args = parse_args()
     log = Log(debug=args.debug)
 
-    try:
-        config = load_config()
-    except Exception as exc:
-        print(f"Config error: {exc}")
+    load_dotenv(DEFAULT_ROOT / ".env")
+    config, errors = validate_config()
+    if errors:
+        report_validation_errors("photos-shuffle.py", errors)
         return 1
+    assert config is not None
+
+    if args.check_config:
+        print("[photos-shuffle.py] Configuration check passed.")
+        return 0
 
     source_image: Path | None = None
     try:

--- a/scripts/piholestats_v1.1.py
+++ b/scripts/piholestats_v1.1.py
@@ -3,10 +3,12 @@
 # v6 auth handled elsewhere; this file only renders and calls API
 # Version 1.1 - Introducing dark mode
 
-import os, sys, time, json, urllib.request, urllib.parse, mmap, struct
+import os, sys, time, json, urllib.request, urllib.parse, mmap, struct, argparse
 from pathlib import Path
 from datetime import datetime
 from PIL import Image, ImageDraw, ImageFont
+
+from _config import get_env, report_validation_errors
 
 # -------- CONFIG --------
 FBDEV = "/dev/fb1"
@@ -14,9 +16,9 @@ W, H = 320, 240
 REFRESH_SECS = 3
 ACTIVE_HOURS = (7, 22)
 
-PIHOLE_HOST = os.environ.get("PIHOLE_HOST", "127.0.0.1")
-PIHOLE_PASSWORD = os.environ.get("PIHOLE_PASSWORD", "")
-PIHOLE_API_TOKEN = os.environ.get("PIHOLE_API_TOKEN", "")
+PIHOLE_HOST = "127.0.0.1"
+PIHOLE_PASSWORD = ""
+PIHOLE_API_TOKEN = ""
 TITLE = "Pi-hole"
 # Colours
 COL_BG   = (0, 0, 0)
@@ -32,31 +34,75 @@ _SID = None
 _SID_EXP = 0.0
 
 
-def _env_int(name, default):
-    raw = os.environ.get(name)
-    if raw is None:
-        return default
+def _parse_int(value: str) -> int:
     try:
-        return int(raw)
-    except ValueError:
-        return default
+        return int(value)
+    except ValueError as exc:
+        raise ValueError(f"expected integer, got {value!r}") from exc
 
 
-def _env_hours(name, default):
-    raw = os.environ.get(name)
-    if raw is None:
-        return default
-    parts = [part.strip() for part in raw.split(",")]
+def _parse_active_hours(value: str) -> tuple[int, int]:
+    parts = [part.strip() for part in value.split(",")]
     if len(parts) != 2:
-        return default
+        raise ValueError("expected format start,end (e.g. 22,7)")
     try:
-        return int(parts[0]), int(parts[1])
-    except ValueError:
-        return default
+        start_hour, end_hour = int(parts[0]), int(parts[1])
+    except ValueError as exc:
+        raise ValueError(f"expected integers in start,end, got {value!r}") from exc
+    for hour in (start_hour, end_hour):
+        if hour < 0 or hour > 23:
+            raise ValueError("hours must be in range 0-23")
+    return start_hour, end_hour
 
 
-REFRESH_SECS = max(1, _env_int("REFRESH_SECS", REFRESH_SECS))
-ACTIVE_HOURS = _env_hours("ACTIVE_HOURS", ACTIVE_HOURS)
+def validate_config() -> tuple[dict[str, object] | None, list[str]]:
+    errors: list[str] = []
+
+    def record(name: str, *, default=None, required=False, validator=None):
+        try:
+            return get_env(name, default=default, required=required, validator=validator)
+        except ValueError as exc:
+            errors.append(str(exc))
+            return default
+
+    fbdev = record("FB_DEVICE", default=FBDEV)
+    host = record("PIHOLE_HOST", default="127.0.0.1")
+    password = record("PIHOLE_PASSWORD", required=True)
+    api_token = record("PIHOLE_API_TOKEN", default="")
+    refresh_secs = record("REFRESH_SECS", default=REFRESH_SECS, validator=_parse_int)
+    active_hours = record("ACTIVE_HOURS", default=f"{ACTIVE_HOURS[0]},{ACTIVE_HOURS[1]}", validator=_parse_active_hours)
+
+    if isinstance(refresh_secs, int) and refresh_secs < 1:
+        errors.append("REFRESH_SECS is invalid: must be greater than or equal to 1")
+
+    if errors:
+        return None, errors
+
+    return {
+        "fbdev": str(fbdev),
+        "pihole_host": str(host),
+        "pihole_password": str(password),
+        "pihole_api_token": str(api_token),
+        "refresh_secs": int(refresh_secs),
+        "active_hours": active_hours if isinstance(active_hours, tuple) else ACTIVE_HOURS,
+    }, []
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Pi-hole framebuffer dashboard")
+    parser.add_argument("--check-config", action="store_true", help="Validate env configuration and exit")
+    return parser.parse_args()
+
+
+def apply_config(config: dict[str, object]) -> None:
+    global FBDEV, PIHOLE_HOST, PIHOLE_PASSWORD, PIHOLE_API_TOKEN, REFRESH_SECS, ACTIVE_HOURS, BASE_URL
+    FBDEV = str(config["fbdev"])
+    PIHOLE_HOST = str(config["pihole_host"])
+    PIHOLE_PASSWORD = str(config["pihole_password"])
+    PIHOLE_API_TOKEN = str(config["pihole_api_token"])
+    REFRESH_SECS = int(config["refresh_secs"])
+    ACTIVE_HOURS = config["active_hours"]
+    BASE_URL = _normalize_host(PIHOLE_HOST)
 
 # ---------- utils ----------
 def load_font(size, bold=False):
@@ -274,9 +320,22 @@ def draw_frame(stats, temp_c, uptime, active):
 
 # ---------- main ----------
 def main():
+    args = parse_args()
+    config, errors = validate_config()
+    if errors:
+        report_validation_errors("piholestats_v1.1.py", errors)
+        return 1
+    assert config is not None
+
+    if args.check_config:
+        print("[piholestats_v1.1.py] Configuration check passed.")
+        return 0
+
+    apply_config(config)
+
     if not Path(FBDEV).exists():
         print(f"Framebuffer {FBDEV} not found.", file=sys.stderr)
-        sys.exit(1)
+        return 1
 
     cached = {"total":0,"blocked":0,"percent":0.0,"ok":False}
     try:
@@ -299,8 +358,10 @@ def main():
         fb_write(frame)
         time.sleep(REFRESH_SECS)
 
+    return 0
+
 if __name__ == "__main__":
     try:
-        main()
+        raise SystemExit(main())
     except KeyboardInterrupt:
         pass

--- a/scripts/piholestats_v1.2.py
+++ b/scripts/piholestats_v1.2.py
@@ -3,10 +3,12 @@
 # v6 auth handled elsewhere; this file only renders and calls API
 # Version 1.2.1 (fixed crash at 23:59) even darker mode
 
-import os, sys, time, json, urllib.request, urllib.parse, mmap, struct
+import os, sys, time, json, urllib.request, urllib.parse, mmap, struct, argparse
 from pathlib import Path
 from datetime import datetime
 from PIL import Image, ImageDraw, ImageFont
+
+from _config import get_env, report_validation_errors
 
 # -------- CONFIG --------
 FBDEV = "/dev/fb1"
@@ -14,9 +16,9 @@ W, H = 320, 240
 REFRESH_SECS = 3
 ACTIVE_HOURS = (22, 7)
 
-PIHOLE_HOST = os.environ.get("PIHOLE_HOST", "127.0.0.1")
-PIHOLE_PASSWORD = os.environ.get("PIHOLE_PASSWORD", "")
-PIHOLE_API_TOKEN = os.environ.get("PIHOLE_API_TOKEN", "")
+PIHOLE_HOST = "127.0.0.1"
+PIHOLE_PASSWORD = ""
+PIHOLE_API_TOKEN = ""
 TITLE = "Pi-hole"
 COL_BG   = (0, 0, 0)
 COL_TXT  = (140,140,140)
@@ -30,31 +32,75 @@ _SID = None
 _SID_EXP = 0.0
 
 
-def _env_int(name, default):
-    raw = os.environ.get(name)
-    if raw is None:
-        return default
+def _parse_int(value: str) -> int:
     try:
-        return int(raw)
-    except ValueError:
-        return default
+        return int(value)
+    except ValueError as exc:
+        raise ValueError(f"expected integer, got {value!r}") from exc
 
 
-def _env_hours(name, default):
-    raw = os.environ.get(name)
-    if raw is None:
-        return default
-    parts = [part.strip() for part in raw.split(",")]
+def _parse_active_hours(value: str) -> tuple[int, int]:
+    parts = [part.strip() for part in value.split(",")]
     if len(parts) != 2:
-        return default
+        raise ValueError("expected format start,end (e.g. 22,7)")
     try:
-        return int(parts[0]), int(parts[1])
-    except ValueError:
-        return default
+        start_hour, end_hour = int(parts[0]), int(parts[1])
+    except ValueError as exc:
+        raise ValueError(f"expected integers in start,end, got {value!r}") from exc
+    for hour in (start_hour, end_hour):
+        if hour < 0 or hour > 23:
+            raise ValueError("hours must be in range 0-23")
+    return start_hour, end_hour
 
 
-REFRESH_SECS = max(1, _env_int("REFRESH_SECS", REFRESH_SECS))
-ACTIVE_HOURS = _env_hours("ACTIVE_HOURS", ACTIVE_HOURS)
+def validate_config() -> tuple[dict[str, object] | None, list[str]]:
+    errors: list[str] = []
+
+    def record(name: str, *, default=None, required=False, validator=None):
+        try:
+            return get_env(name, default=default, required=required, validator=validator)
+        except ValueError as exc:
+            errors.append(str(exc))
+            return default
+
+    fbdev = record("FB_DEVICE", default=FBDEV)
+    host = record("PIHOLE_HOST", default="127.0.0.1")
+    password = record("PIHOLE_PASSWORD", required=True)
+    api_token = record("PIHOLE_API_TOKEN", default="")
+    refresh_secs = record("REFRESH_SECS", default=REFRESH_SECS, validator=_parse_int)
+    active_hours = record("ACTIVE_HOURS", default=f"{ACTIVE_HOURS[0]},{ACTIVE_HOURS[1]}", validator=_parse_active_hours)
+
+    if isinstance(refresh_secs, int) and refresh_secs < 1:
+        errors.append("REFRESH_SECS is invalid: must be greater than or equal to 1")
+
+    if errors:
+        return None, errors
+
+    return {
+        "fbdev": str(fbdev),
+        "pihole_host": str(host),
+        "pihole_password": str(password),
+        "pihole_api_token": str(api_token),
+        "refresh_secs": int(refresh_secs),
+        "active_hours": active_hours if isinstance(active_hours, tuple) else ACTIVE_HOURS,
+    }, []
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Pi-hole framebuffer dashboard")
+    parser.add_argument("--check-config", action="store_true", help="Validate env configuration and exit")
+    return parser.parse_args()
+
+
+def apply_config(config: dict[str, object]) -> None:
+    global FBDEV, PIHOLE_HOST, PIHOLE_PASSWORD, PIHOLE_API_TOKEN, REFRESH_SECS, ACTIVE_HOURS, BASE_URL
+    FBDEV = str(config["fbdev"])
+    PIHOLE_HOST = str(config["pihole_host"])
+    PIHOLE_PASSWORD = str(config["pihole_password"])
+    PIHOLE_API_TOKEN = str(config["pihole_api_token"])
+    REFRESH_SECS = int(config["refresh_secs"])
+    ACTIVE_HOURS = config["active_hours"]
+    BASE_URL = _normalize_host(PIHOLE_HOST)
 
 # ---------- utils ----------
 def load_font(size, bold=False):
@@ -257,9 +303,22 @@ def draw_frame(stats, temp_c, uptime, active):
 
 # ---------- main ----------
 def main():
+    args = parse_args()
+    config, errors = validate_config()
+    if errors:
+        report_validation_errors("piholestats_v1.2.py", errors)
+        return 1
+    assert config is not None
+
+    if args.check_config:
+        print("[piholestats_v1.2.py] Configuration check passed.")
+        return 0
+
+    apply_config(config)
+
     if not Path(FBDEV).exists():
         print(f"Framebuffer {FBDEV} not found.", file=sys.stderr)
-        sys.exit(1)
+        return 1
 
     cached = {"total":0,"blocked":0,"percent":0.0,"ok":False}
     try:
@@ -284,13 +343,14 @@ def main():
         temp_c = read_temp_c()
         uptime = read_uptime_str()
 
-        # fixed crash at midnight (text_size now always called with correct args)
         frame = draw_frame(cached, temp_c, uptime, active)
         fb_write(frame)
         time.sleep(REFRESH_SECS)
 
+    return 0
+
 if __name__ == "__main__":
     try:
-        main()
+        raise SystemExit(main())
     except KeyboardInterrupt:
         pass


### PR DESCRIPTION
### Motivation
- Centralize environment parsing/validation to provide consistent, user-friendly errors across dashboard scripts.
- Make it easy to validate configuration without running the full app by adding a `--check-config` mode.
- Provide sensible non-sensitive defaults (paths, ports, toggles) while keeping secrets required and clearly reported when missing.

### Description
- Added a shared helper `scripts/_config.py` that exposes `get_env(name, default=None, required=False, validator=None)` and `report_validation_errors(...)` for normalized env reading and error reporting.
- Introduced `validate_config()` functions in `scripts/calendash-api.py`, `scripts/photos-shuffle.py`, `scripts/piholestats_v1.1.py`, and `scripts/piholestats_v1.2.py` that aggregate missing/invalid values and return a single structured error list.
- Hooked each script up to the shared helpers and added a `--check-config` CLI flag that runs validation and exits (prints pass/fail report) without starting the main application logic.
- Updated `.env.example` to document which variables are required vs optional and to list script defaults (token paths, image paths, sizes, ports, and toggles).

### Testing
- Ran bytecode checks with `python -m py_compile scripts/_config.py scripts/calendash-api.py scripts/photos-shuffle.py scripts/piholestats_v1.2.py scripts/piholestats_v1.1.py`, which succeeded.
- Attempted runtime config checks: `python scripts/calendash-api.py --check-config` failed due to missing dependency `pytz` in the test environment.
- Attempted runtime config checks: `python scripts/photos-shuffle.py --check-config` failed due to missing dependency `python-dotenv` in the test environment.
- Attempted runtime config checks: `python scripts/piholestats_v1.2.py --check-config` failed due to missing dependency `Pillow` in the test environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acb3735ccc8320a70650c07e0857b9)