### PR TITLE
Fix Pi-hole active-hours logic and document cross-midnight support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,7 +41,8 @@ PIHOLE_API_TOKEN=
 FB_DEVICE=/dev/fb1
 # Optional refresh interval seconds, default: 3
 REFRESH_SECS=3
-# Optional active window as start,end in 24h format. Defaults depend on script version.
+# Optional active window as start,end in 24h format (inclusive). Defaults depend on script version.
+# Cross-midnight windows are supported, e.g. 22,7 means 22:00 through 07:59.
 ACTIVE_HOURS=22,7
 
 # --- Google Photos (photos-shuffle.py) ---

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Set at minimum:
 - `PIHOLE_PASSWORD`
 - `PIHOLE_API_TOKEN` (optional fallback)
 - `REFRESH_SECS`
-- `ACTIVE_HOURS`
+- `ACTIVE_HOURS` (inclusive `start,end` hour window in 24h format; cross-midnight values like `22,7` are supported)
 
 ## Run via systemd
 

--- a/scripts/piholestats_v1.1.py
+++ b/scripts/piholestats_v1.1.py
@@ -51,9 +51,47 @@ def _parse_active_hours(value: str) -> tuple[int, int]:
     except ValueError as exc:
         raise ValueError(f"expected integers in start,end, got {value!r}") from exc
     for hour in (start_hour, end_hour):
-        if hour < 0 or hour > 23:
-            raise ValueError("hours must be in range 0-23")
+        validate_hour_bounds(hour)
     return start_hour, end_hour
+
+
+def validate_hour_bounds(hour: int) -> None:
+    if hour < 0 or hour > 23:
+        raise ValueError(f"hour must be in range 0-23, got {hour}")
+
+
+def is_hour_active(now_hour: int, start: int, end: int) -> bool:
+    validate_hour_bounds(now_hour)
+    validate_hour_bounds(start)
+    validate_hour_bounds(end)
+    if start <= end:
+        return start <= now_hour <= end
+    return now_hour >= start or now_hour <= end
+
+
+def run_self_checks() -> None:
+    # Non-wrapping range.
+    assert is_hour_active(8, 8, 17)
+    assert is_hour_active(17, 8, 17)
+    assert not is_hour_active(7, 8, 17)
+    # Cross-midnight range.
+    assert is_hour_active(23, 22, 7)
+    assert is_hour_active(3, 22, 7)
+    assert not is_hour_active(12, 22, 7)
+    # Single-hour range.
+    assert is_hour_active(0, 0, 0)
+    assert not is_hour_active(1, 0, 0)
+    # Late-night to early-morning range.
+    assert is_hour_active(23, 23, 2)
+    assert is_hour_active(1, 23, 2)
+    assert not is_hour_active(10, 23, 2)
+
+    for invalid_hour in (-1, 24):
+        try:
+            is_hour_active(invalid_hour, 8, 17)
+            raise AssertionError("expected ValueError for out-of-range hour")
+        except ValueError:
+            pass
 
 
 def validate_config() -> tuple[dict[str, object] | None, list[str]]:
@@ -92,6 +130,7 @@ def validate_config() -> tuple[dict[str, object] | None, list[str]]:
 def parse_args():
     parser = argparse.ArgumentParser(description="Pi-hole framebuffer dashboard")
     parser.add_argument("--check-config", action="store_true", help="Validate env configuration and exit")
+    parser.add_argument("--self-test", action="store_true", help="Run active-hours self checks and exit")
     return parser.parse_args()
 
 
@@ -322,6 +361,12 @@ def draw_frame(stats, temp_c, uptime, active):
 # ---------- main ----------
 def main():
     args = parse_args()
+
+    if args.self_test:
+        run_self_checks()
+        print(f"[piholestats_v1.1.py] Self checks passed.")
+        return 0
+
     config, errors = validate_config()
     if errors:
         report_validation_errors("piholestats_v1.1.py", errors)
@@ -346,7 +391,7 @@ def main():
 
     while True:
         hr = time.localtime().tm_hour
-        active = (ACTIVE_HOURS[0] <= hr <= ACTIVE_HOURS[1])
+        active = is_hour_active(hr, ACTIVE_HOURS[0], ACTIVE_HOURS[1])
 
         s = fetch_pihole()
         if s["ok"]:

--- a/scripts/piholestats_v1.2.py
+++ b/scripts/piholestats_v1.2.py
@@ -48,9 +48,47 @@ def _parse_active_hours(value: str) -> tuple[int, int]:
     except ValueError as exc:
         raise ValueError(f"expected integers in start,end, got {value!r}") from exc
     for hour in (start_hour, end_hour):
-        if hour < 0 or hour > 23:
-            raise ValueError("hours must be in range 0-23")
+        validate_hour_bounds(hour)
     return start_hour, end_hour
+
+
+def validate_hour_bounds(hour: int) -> None:
+    if hour < 0 or hour > 23:
+        raise ValueError(f"hour must be in range 0-23, got {hour}")
+
+
+def is_hour_active(now_hour: int, start: int, end: int) -> bool:
+    validate_hour_bounds(now_hour)
+    validate_hour_bounds(start)
+    validate_hour_bounds(end)
+    if start <= end:
+        return start <= now_hour <= end
+    return now_hour >= start or now_hour <= end
+
+
+def run_self_checks() -> None:
+    # Non-wrapping range.
+    assert is_hour_active(8, 8, 17)
+    assert is_hour_active(17, 8, 17)
+    assert not is_hour_active(7, 8, 17)
+    # Cross-midnight range.
+    assert is_hour_active(23, 22, 7)
+    assert is_hour_active(3, 22, 7)
+    assert not is_hour_active(12, 22, 7)
+    # Single-hour range.
+    assert is_hour_active(0, 0, 0)
+    assert not is_hour_active(1, 0, 0)
+    # Late-night to early-morning range.
+    assert is_hour_active(23, 23, 2)
+    assert is_hour_active(1, 23, 2)
+    assert not is_hour_active(10, 23, 2)
+
+    for invalid_hour in (-1, 24):
+        try:
+            is_hour_active(invalid_hour, 8, 17)
+            raise AssertionError("expected ValueError for out-of-range hour")
+        except ValueError:
+            pass
 
 
 def validate_config() -> tuple[dict[str, object] | None, list[str]]:
@@ -89,6 +127,7 @@ def validate_config() -> tuple[dict[str, object] | None, list[str]]:
 def parse_args():
     parser = argparse.ArgumentParser(description="Pi-hole framebuffer dashboard")
     parser.add_argument("--check-config", action="store_true", help="Validate env configuration and exit")
+    parser.add_argument("--self-test", action="store_true", help="Run active-hours self checks and exit")
     return parser.parse_args()
 
 
@@ -304,6 +343,12 @@ def draw_frame(stats, temp_c, uptime, active):
 # ---------- main ----------
 def main():
     args = parse_args()
+
+    if args.self_test:
+        run_self_checks()
+        print(f"[piholestats_v1.2.py] Self checks passed.")
+        return 0
+
     config, errors = validate_config()
     if errors:
         report_validation_errors("piholestats_v1.2.py", errors)
@@ -327,14 +372,14 @@ def main():
         pass
 
     hr = time.localtime().tm_hour
-    active = (ACTIVE_HOURS[0] <= hr <= ACTIVE_HOURS[1])
+    active = is_hour_active(hr, ACTIVE_HOURS[0], ACTIVE_HOURS[1])
     temp_c = read_temp_c()
     uptime = read_uptime_str()
     fb_write(draw_frame(cached, temp_c, uptime, active))
 
     while True:
         hr = time.localtime().tm_hour
-        active = (ACTIVE_HOURS[0] <= hr <= ACTIVE_HOURS[1])
+        active = is_hour_active(hr, ACTIVE_HOURS[0], ACTIVE_HOURS[1])
 
         s = fetch_pihole()
         if s["ok"]:


### PR DESCRIPTION
### Motivation
- The existing inline active-hour comparisons did not correctly handle cross-midnight ranges and lacked explicit validation of hour bounds.
- Add a clear helper and coverage to make active-window semantics predictable and document cross-midnight support.

### Description
- Added `validate_hour_bounds(hour)` to enforce hours in `0..23` and `is_hour_active(now_hour, start, end)` implementing inclusive same-day (`start <= hour <= end`) and cross-midnight (`hour >= start or hour <= end`) semantics.
- Replaced inline comparisons with `is_hour_active(...)` in `scripts/piholestats_v1.1.py` and `scripts/piholestats_v1.2.py` for startup and main loop checks.
- Added `run_self_checks()` with representative assertions for `8,17`, `22,7`, `0,0`, `23,2` and invalid bounds, and exposed it via a `--self-test` CLI flag in both scripts.
- Updated `.env.example` and `README.md` to explicitly state `ACTIVE_HOURS` is inclusive and that cross-midnight windows (e.g. `22,7`) are supported.

### Testing
- Ran `python3 -m py_compile scripts/piholestats_v1.2.py scripts/piholestats_v1.1.py` which completed successfully.
- Attempting `python3 scripts/piholestats_v1.2.py --self-test` in this environment failed due to missing `Pillow` (`PIL`) which is expected on systems without GUI/font libs.
- Executed both scripts' self-tests in-process by stubbing a minimal `PIL` module and adding the `scripts` folder to `sys.path` (via a short `runpy` test driver), and both `--self-test` paths passed and printed success messages.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ace05374ac83208777aebde9119e2e)