### PR TITLE
Add configurable scheme and TLS verification to Pi-hole dashboard scripts

### DIFF
--- a/scripts/piholestats_v1.1.py
+++ b/scripts/piholestats_v1.1.py
@@ -4,7 +4,7 @@
 # Version 1.1 - Introducing dark mode
 # LEGACY: kept for compatibility/manual use; canonical night service uses piholestats_v1.2.py
 
-import os, sys, time, json, urllib.request, urllib.parse, mmap, struct, argparse
+import os, sys, time, json, urllib.request, urllib.parse, mmap, struct, argparse, ssl
 from pathlib import Path
 from datetime import datetime
 from PIL import Image, ImageDraw, ImageFont
@@ -18,6 +18,9 @@ REFRESH_SECS = 3
 ACTIVE_HOURS = (7, 22)
 
 PIHOLE_HOST = "127.0.0.1"
+PIHOLE_SCHEME = ""
+PIHOLE_VERIFY_TLS = "auto"
+PIHOLE_CA_BUNDLE = ""
 PIHOLE_PASSWORD = ""
 PIHOLE_API_TOKEN = ""
 TITLE = "Pi-hole"
@@ -33,6 +36,8 @@ COL_UP   = (60,30,100)
 
 _SID = None
 _SID_EXP = 0.0
+REQUEST_TIMEOUT = 4.0
+REQUEST_TLS_VERIFY: bool | str = True
 
 
 def _parse_int(value: str) -> int:
@@ -53,6 +58,27 @@ def _parse_active_hours(value: str) -> tuple[int, int]:
     for hour in (start_hour, end_hour):
         validate_hour_bounds(hour)
     return start_hour, end_hour
+
+
+def _parse_float(value: str) -> float:
+    try:
+        return float(value)
+    except ValueError as exc:
+        raise ValueError(f"expected number, got {value!r}") from exc
+
+
+def _parse_scheme(value: str) -> str:
+    scheme = value.strip().lower()
+    if scheme not in {"http", "https"}:
+        raise ValueError("expected 'http' or 'https'")
+    return scheme
+
+
+def _parse_verify_tls(value: str) -> str:
+    normalized = value.strip().lower()
+    if normalized not in {"auto", "true", "false", "1", "0", "yes", "no"}:
+        raise ValueError("expected one of auto/true/false")
+    return normalized
 
 
 def validate_hour_bounds(hour: int) -> None:
@@ -106,13 +132,21 @@ def validate_config() -> tuple[dict[str, object] | None, list[str]]:
 
     fbdev = record("FB_DEVICE", default=FBDEV)
     host = record("PIHOLE_HOST", default="127.0.0.1")
+    scheme = record("PIHOLE_SCHEME", default="", validator=_parse_scheme)
+    verify_tls = record("PIHOLE_VERIFY_TLS", default="auto", validator=_parse_verify_tls)
+    ca_bundle = record("PIHOLE_CA_BUNDLE", default="")
     password = record("PIHOLE_PASSWORD", required=True)
     api_token = record("PIHOLE_API_TOKEN", default="")
     refresh_secs = record("REFRESH_SECS", default=REFRESH_SECS, validator=_parse_int)
+    request_timeout = record("PIHOLE_TIMEOUT", default=REQUEST_TIMEOUT, validator=_parse_float)
     active_hours = record("ACTIVE_HOURS", default=f"{ACTIVE_HOURS[0]},{ACTIVE_HOURS[1]}", validator=_parse_active_hours)
 
     if isinstance(refresh_secs, int) and refresh_secs < 1:
         errors.append("REFRESH_SECS is invalid: must be greater than or equal to 1")
+    if isinstance(request_timeout, float) and request_timeout <= 0:
+        errors.append("PIHOLE_TIMEOUT is invalid: must be greater than 0")
+    if ca_bundle and not Path(str(ca_bundle)).is_file():
+        errors.append("PIHOLE_CA_BUNDLE is invalid: file does not exist")
 
     if errors:
         return None, errors
@@ -120,8 +154,12 @@ def validate_config() -> tuple[dict[str, object] | None, list[str]]:
     return {
         "fbdev": str(fbdev),
         "pihole_host": str(host),
+        "pihole_scheme": str(scheme),
+        "pihole_verify_tls": str(verify_tls),
+        "pihole_ca_bundle": str(ca_bundle),
         "pihole_password": str(password),
         "pihole_api_token": str(api_token),
+        "request_timeout": float(request_timeout),
         "refresh_secs": int(refresh_secs),
         "active_hours": active_hours if isinstance(active_hours, tuple) else ACTIVE_HOURS,
     }, []
@@ -135,14 +173,21 @@ def parse_args():
 
 
 def apply_config(config: dict[str, object]) -> None:
-    global FBDEV, PIHOLE_HOST, PIHOLE_PASSWORD, PIHOLE_API_TOKEN, REFRESH_SECS, ACTIVE_HOURS, BASE_URL
+    global FBDEV, PIHOLE_HOST, PIHOLE_SCHEME, PIHOLE_VERIFY_TLS, PIHOLE_CA_BUNDLE
+    global PIHOLE_PASSWORD, PIHOLE_API_TOKEN, REFRESH_SECS, ACTIVE_HOURS, BASE_URL
+    global REQUEST_TIMEOUT, REQUEST_TLS_VERIFY
     FBDEV = str(config["fbdev"])
     PIHOLE_HOST = str(config["pihole_host"])
+    PIHOLE_SCHEME = str(config["pihole_scheme"])
+    PIHOLE_VERIFY_TLS = str(config["pihole_verify_tls"])
+    PIHOLE_CA_BUNDLE = str(config["pihole_ca_bundle"])
     PIHOLE_PASSWORD = str(config["pihole_password"])
     PIHOLE_API_TOKEN = str(config["pihole_api_token"])
+    REQUEST_TIMEOUT = float(config["request_timeout"])
     REFRESH_SECS = int(config["refresh_secs"])
     ACTIVE_HOURS = config["active_hours"]
-    BASE_URL = _normalize_host(PIHOLE_HOST)
+    BASE_URL = _normalize_host(PIHOLE_HOST, preferred_scheme=PIHOLE_SCHEME)
+    REQUEST_TLS_VERIFY = _resolve_tls_verify(BASE_URL, PIHOLE_VERIFY_TLS, PIHOLE_CA_BUNDLE)
 
 # ---------- utils ----------
 def load_font(size, bold=False):
@@ -206,20 +251,54 @@ def read_uptime_str():
         return "N/A"
 
 # ---------- Pi-hole v6 auth + fetch ----------
-def _http_json(url, method="GET", body=None, timeout=3):
+def _is_local_host(hostname: str) -> bool:
+    normalized = hostname.strip("[]").lower()
+    return normalized in {"localhost", "::1"} or normalized.startswith("127.")
+
+
+def _resolve_scheme(raw_host: str, preferred_scheme: str = "") -> str:
+    if preferred_scheme:
+        return preferred_scheme
+    parsed = urllib.parse.urlsplit(raw_host)
+    if parsed.scheme:
+        return parsed.scheme
+    hostname = parsed.hostname or raw_host.split("/")[0].split(":")[0]
+    return "http" if _is_local_host(hostname) else "https"
+
+
+def _resolve_tls_verify(base_url: str, verify_setting: str, ca_bundle: str):
+    normalized = verify_setting.strip().lower()
+    if ca_bundle:
+        return ca_bundle
+    if normalized in {"true", "1", "yes"}:
+        return True
+    if normalized in {"false", "0", "no"}:
+        return False
+    parsed = urllib.parse.urlsplit(base_url)
+    return parsed.scheme == "https" and not _is_local_host(parsed.hostname or "")
+
+
+def _http_json(url, method="GET", body=None, timeout=None):
     headers = {"Content-Type": "application/json"} if body is not None else {}
     data = json.dumps(body).encode("utf-8") if body is not None else None
     req = urllib.request.Request(url, data=data, headers=headers, method=method)
-    with urllib.request.urlopen(req, timeout=timeout) as r:
+    effective_timeout = REQUEST_TIMEOUT if timeout is None else timeout
+    context = None
+    if url.startswith("https://"):
+        if REQUEST_TLS_VERIFY is False:
+            context = ssl._create_unverified_context()
+        elif isinstance(REQUEST_TLS_VERIFY, str):
+            context = ssl.create_default_context(cafile=REQUEST_TLS_VERIFY)
+    with urllib.request.urlopen(req, timeout=effective_timeout, context=context) as r:
         return json.loads(r.read().decode("utf-8"))
 
 
-def _normalize_host(raw_host: str) -> str:
+def _normalize_host(raw_host: str, preferred_scheme: str = "") -> str:
     host = raw_host.strip()
     if not host:
-        return "http://127.0.0.1"
+        host = "127.0.0.1"
     if not host.startswith(("http://", "https://")):
-        host = f"http://{host}"
+        host = f"{_resolve_scheme(host, preferred_scheme)}://{host}"
     parsed = urllib.parse.urlsplit(host)
     if parsed.path.startswith("/admin"):
         parsed = parsed._replace(path="")
@@ -227,7 +306,7 @@ def _normalize_host(raw_host: str) -> str:
     return urllib.parse.urlunsplit(cleaned).rstrip("/")
 
 
-BASE_URL = _normalize_host(PIHOLE_HOST)
+BASE_URL = _normalize_host(PIHOLE_HOST, preferred_scheme=PIHOLE_SCHEME)
 
 def _auth_get_sid():
     global _SID, _SID_EXP

--- a/scripts/piholestats_v1.2.py
+++ b/scripts/piholestats_v1.2.py
@@ -3,7 +3,7 @@
 # v6 auth handled elsewhere; this file only renders and calls API
 # Version 1.2.1 (fixed crash at 23:59) even darker mode
 
-import os, sys, time, json, urllib.request, urllib.parse, mmap, struct, argparse
+import os, sys, time, json, urllib.request, urllib.parse, mmap, struct, argparse, ssl
 from pathlib import Path
 from datetime import datetime
 from PIL import Image, ImageDraw, ImageFont
@@ -17,6 +17,9 @@ REFRESH_SECS = 3
 ACTIVE_HOURS = (22, 7)
 
 PIHOLE_HOST = "127.0.0.1"
+PIHOLE_SCHEME = ""
+PIHOLE_VERIFY_TLS = "auto"
+PIHOLE_CA_BUNDLE = ""
 PIHOLE_PASSWORD = ""
 PIHOLE_API_TOKEN = ""
 TITLE = "Pi-hole"
@@ -30,6 +33,8 @@ COL_UP   = (24,12,40)
 
 _SID = None
 _SID_EXP = 0.0
+REQUEST_TIMEOUT = 4.0
+REQUEST_TLS_VERIFY: bool | str = True
 
 
 def _parse_int(value: str) -> int:
@@ -50,6 +55,27 @@ def _parse_active_hours(value: str) -> tuple[int, int]:
     for hour in (start_hour, end_hour):
         validate_hour_bounds(hour)
     return start_hour, end_hour
+
+
+def _parse_float(value: str) -> float:
+    try:
+        return float(value)
+    except ValueError as exc:
+        raise ValueError(f"expected number, got {value!r}") from exc
+
+
+def _parse_scheme(value: str) -> str:
+    scheme = value.strip().lower()
+    if scheme not in {"http", "https"}:
+        raise ValueError("expected 'http' or 'https'")
+    return scheme
+
+
+def _parse_verify_tls(value: str) -> str:
+    normalized = value.strip().lower()
+    if normalized not in {"auto", "true", "false", "1", "0", "yes", "no"}:
+        raise ValueError("expected one of auto/true/false")
+    return normalized
 
 
 def validate_hour_bounds(hour: int) -> None:
@@ -103,13 +129,21 @@ def validate_config() -> tuple[dict[str, object] | None, list[str]]:
 
     fbdev = record("FB_DEVICE", default=FBDEV)
     host = record("PIHOLE_HOST", default="127.0.0.1")
+    scheme = record("PIHOLE_SCHEME", default="", validator=_parse_scheme)
+    verify_tls = record("PIHOLE_VERIFY_TLS", default="auto", validator=_parse_verify_tls)
+    ca_bundle = record("PIHOLE_CA_BUNDLE", default="")
     password = record("PIHOLE_PASSWORD", required=True)
     api_token = record("PIHOLE_API_TOKEN", default="")
     refresh_secs = record("REFRESH_SECS", default=REFRESH_SECS, validator=_parse_int)
+    request_timeout = record("PIHOLE_TIMEOUT", default=REQUEST_TIMEOUT, validator=_parse_float)
     active_hours = record("ACTIVE_HOURS", default=f"{ACTIVE_HOURS[0]},{ACTIVE_HOURS[1]}", validator=_parse_active_hours)
 
     if isinstance(refresh_secs, int) and refresh_secs < 1:
         errors.append("REFRESH_SECS is invalid: must be greater than or equal to 1")
+    if isinstance(request_timeout, float) and request_timeout <= 0:
+        errors.append("PIHOLE_TIMEOUT is invalid: must be greater than 0")
+    if ca_bundle and not Path(str(ca_bundle)).is_file():
+        errors.append("PIHOLE_CA_BUNDLE is invalid: file does not exist")
 
     if errors:
         return None, errors
@@ -117,8 +151,12 @@ def validate_config() -> tuple[dict[str, object] | None, list[str]]:
     return {
         "fbdev": str(fbdev),
         "pihole_host": str(host),
+        "pihole_scheme": str(scheme),
+        "pihole_verify_tls": str(verify_tls),
+        "pihole_ca_bundle": str(ca_bundle),
         "pihole_password": str(password),
         "pihole_api_token": str(api_token),
+        "request_timeout": float(request_timeout),
         "refresh_secs": int(refresh_secs),
         "active_hours": active_hours if isinstance(active_hours, tuple) else ACTIVE_HOURS,
     }, []
@@ -132,14 +170,21 @@ def parse_args():
 
 
 def apply_config(config: dict[str, object]) -> None:
-    global FBDEV, PIHOLE_HOST, PIHOLE_PASSWORD, PIHOLE_API_TOKEN, REFRESH_SECS, ACTIVE_HOURS, BASE_URL
+    global FBDEV, PIHOLE_HOST, PIHOLE_SCHEME, PIHOLE_VERIFY_TLS, PIHOLE_CA_BUNDLE
+    global PIHOLE_PASSWORD, PIHOLE_API_TOKEN, REFRESH_SECS, ACTIVE_HOURS, BASE_URL
+    global REQUEST_TIMEOUT, REQUEST_TLS_VERIFY
     FBDEV = str(config["fbdev"])
     PIHOLE_HOST = str(config["pihole_host"])
+    PIHOLE_SCHEME = str(config["pihole_scheme"])
+    PIHOLE_VERIFY_TLS = str(config["pihole_verify_tls"])
+    PIHOLE_CA_BUNDLE = str(config["pihole_ca_bundle"])
     PIHOLE_PASSWORD = str(config["pihole_password"])
     PIHOLE_API_TOKEN = str(config["pihole_api_token"])
+    REQUEST_TIMEOUT = float(config["request_timeout"])
     REFRESH_SECS = int(config["refresh_secs"])
     ACTIVE_HOURS = config["active_hours"]
-    BASE_URL = _normalize_host(PIHOLE_HOST)
+    BASE_URL = _normalize_host(PIHOLE_HOST, preferred_scheme=PIHOLE_SCHEME)
+    REQUEST_TLS_VERIFY = _resolve_tls_verify(BASE_URL, PIHOLE_VERIFY_TLS, PIHOLE_CA_BUNDLE)
 
 # ---------- utils ----------
 def load_font(size, bold=False):
@@ -203,19 +248,54 @@ def read_uptime_str():
         return "N/A"
 
 # ---------- Pi-hole v6 auth + fetch ----------
-def _http_json(url, method="GET", body=None, timeout=3):
+def _is_local_host(hostname: str) -> bool:
+    normalized = hostname.strip("[]").lower()
+    return normalized in {"localhost", "::1"} or normalized.startswith("127.")
+
+
+def _resolve_scheme(raw_host: str, preferred_scheme: str = "") -> str:
+    if preferred_scheme:
+        return preferred_scheme
+    parsed = urllib.parse.urlsplit(raw_host)
+    if parsed.scheme:
+        return parsed.scheme
+    hostname = parsed.hostname or raw_host.split("/")[0].split(":")[0]
+    return "http" if _is_local_host(hostname) else "https"
+
+
+def _resolve_tls_verify(base_url: str, verify_setting: str, ca_bundle: str):
+    normalized = verify_setting.strip().lower()
+    if ca_bundle:
+        return ca_bundle
+    if normalized in {"true", "1", "yes"}:
+        return True
+    if normalized in {"false", "0", "no"}:
+        return False
+    parsed = urllib.parse.urlsplit(base_url)
+    return parsed.scheme == "https" and not _is_local_host(parsed.hostname or "")
+
+
+def _http_json(url, method="GET", body=None, timeout=None):
     headers = {"Content-Type": "application/json"} if body is not None else {}
     data = json.dumps(body).encode("utf-8") if body is not None else None
     req = urllib.request.Request(url, data=data, headers=headers, method=method)
-    with urllib.request.urlopen(req, timeout=timeout) as r:
+    effective_timeout = REQUEST_TIMEOUT if timeout is None else timeout
+    context = None
+    if url.startswith("https://"):
+        if REQUEST_TLS_VERIFY is False:
+            context = ssl._create_unverified_context()
+        elif isinstance(REQUEST_TLS_VERIFY, str):
+            context = ssl.create_default_context(cafile=REQUEST_TLS_VERIFY)
+    with urllib.request.urlopen(req, timeout=effective_timeout, context=context) as r:
         return json.loads(r.read().decode("utf-8"))
 
-def _normalize_host(raw_host: str) -> str:
+
+def _normalize_host(raw_host: str, preferred_scheme: str = "") -> str:
     host = raw_host.strip()
     if not host:
-        return "http://127.0.0.1"
+        host = "127.0.0.1"
     if not host.startswith(("http://", "https://")):
-        host = f"http://{host}"
+        host = f"{_resolve_scheme(host, preferred_scheme)}://{host}"
     parsed = urllib.parse.urlsplit(host)
     if parsed.path.startswith("/admin"):
         parsed = parsed._replace(path="")
@@ -223,7 +303,7 @@ def _normalize_host(raw_host: str) -> str:
     return urllib.parse.urlunsplit(cleaned).rstrip("/")
 
 
-BASE_URL = _normalize_host(PIHOLE_HOST)
+BASE_URL = _normalize_host(PIHOLE_HOST, preferred_scheme=PIHOLE_SCHEME)
 
 
 def _auth_get_sid():


### PR DESCRIPTION
### Motivation
- Preserve an explicit scheme when provided in `PIHOLE_HOST` and avoid forcing `http://` by default. 
- Allow operators to control TLS verification behavior and CA bundle path to support secure non-local hosts and special CA setups. 
- Centralize and respect request timeout and TLS verification settings for all Pi-hole API calls.

### Description
- Added environment-driven options `PIHOLE_SCHEME`, `PIHOLE_VERIFY_TLS`, `PIHOLE_CA_BUNDLE`, and `PIHOLE_TIMEOUT` with validators and wiring in `validate_config()` and `apply_config()` in both `scripts/piholestats_v1.2.py` and `scripts/piholestats_v1.1.py`.
- Implemented `_resolve_scheme()` and updated `_normalize_host()` to preserve an explicit scheme and to auto-select `http` for local hosts and `https` for non-local hosts when no scheme is provided (honoring `PIHOLE_SCHEME` when set).
- Implemented `_resolve_tls_verify()` and applied TLS handling in `_http_json()` to build an `ssl` context that supports: verify off, default verification, or verification using a provided CA bundle; requests now use the centralized timeout (`PIHOLE_TIMEOUT`).
- Added config validation for `PIHOLE_TIMEOUT` (>0) and existence check for `PIHOLE_CA_BUNDLE`, and mirrored all changes across v1.2 and v1.1 scripts.

### Testing
- Successfully compiled both updated scripts with `python -m py_compile scripts/piholestats_v1.2.py scripts/piholestats_v1.1.py` (no syntax errors).
- Attempted runtime self-tests via `python scripts/piholestats_v1.2.py --self-test` and `python scripts/piholestats_v1.1.py --self-test`, but execution was blocked by missing runtime dependency (`ModuleNotFoundError: No module named 'PIL'`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ace26cc7288320ae48dcb9690139ea)