### PR TITLE
Persist refreshed Google Photos token atomically

### DIFF
--- a/scripts/photos-shuffle.py
+++ b/scripts/photos-shuffle.py
@@ -43,6 +43,7 @@ import argparse
 import json
 import os
 import random
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -259,6 +260,8 @@ def authenticate(config: Config, log: Log) -> Credentials:
         log.debug("Refreshing existing Google OAuth token")
         try:
             creds.refresh(Request())
+            _write_token_atomically(config.token_path, creds.to_json())
+            log.info(f"Google OAuth token refreshed and saved to {config.token_path}")
         except Exception as exc:
             log.info(f"Token refresh failed ({exc}); starting OAuth flow")
             creds = None
@@ -301,10 +304,19 @@ def authenticate(config: Config, log: Log) -> Credentials:
                 log.info("Set GOOGLE_PHOTOS_CLIENT_ID / GOOGLE_PHOTOS_CLIENT_SECRET (or GOOGLE_PHOTOS_CLIENT_SECRETS_PATH) in .env.")
             raise
 
-    config.token_path.parent.mkdir(parents=True, exist_ok=True)
-    config.token_path.write_text(creds.to_json(), encoding="utf-8")
+    _write_token_atomically(config.token_path, creds.to_json())
     log.debug(f"Saved OAuth token to {config.token_path}")
     return creds
+
+
+def _write_token_atomically(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, delete=False) as tmp_file:
+        tmp_file.write(content)
+        tmp_file.flush()
+        os.fsync(tmp_file.fileno())
+        temp_path = Path(tmp_file.name)
+    temp_path.replace(path)
 
 
 def list_album_images(creds: Credentials, album_id: str, log: Log) -> list[dict[str, Any]]:


### PR DESCRIPTION
### Motivation
- Avoid risk of token file corruption by writing updated OAuth tokens atomically after a refresh or initial OAuth flow.
- Ensure a refresh success is recorded without printing sensitive token values to logs.

### Description
- Added an atomic writer helper `
_write_token_atomically(path: Path, content: str)` that writes to a temporary file, fsyncs, and renames into place.
- Call the atomic writer immediately after `creds.refresh(Request())` to persist refreshed credentials and log a non-sensitive confirmation with the token path only.
- Replaced the previous direct `Path.write_text(...)` usage after the OAuth flow with the same atomic writer and added the required `import tempfile`.

### Testing
- Ran `python -m py_compile scripts/photos-shuffle.py` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad0203203083209394f27a7706586c)