### PR TITLE
Resolve photos logo path relative to repo/script and warn once if missing

### DIFF
--- a/scripts/photos-shuffle.py
+++ b/scripts/photos-shuffle.py
@@ -65,6 +65,9 @@ TEST_OUTPUT = Path("/tmp/photos-shuffle-test.png")
 LOGO_WIDTH_RATIO = 0.14
 LOGO_PADDING_RATIO = 0.03
 BRIGHTNESS_FACTOR = 0.75
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent
+DEFAULT_LOGO_RELATIVE_PATH = Path("images/goo-photos-icon.png")
 
 CREDENTIAL_SOURCES_CHECKLIST = [
     "GOOGLE_PHOTOS_CLIENT_SECRETS_PATH file (env/.env; default: ~/zero2dash/client_secret.json)",
@@ -86,6 +89,7 @@ class Config:
     cache_dir: Path
     fallback_image: Path
     logo_path: Path
+    logo_attempted_paths: list[Path]
     oauth_port: int
     oauth_open_browser: bool
 
@@ -146,6 +150,23 @@ def format_credentials_checklist() -> str:
     )
 
 
+def resolve_repo_or_script_relative_path(path_raw: str) -> tuple[Path, list[Path]]:
+    expanded = Path(path_raw).expanduser()
+    if expanded.is_absolute():
+        return expanded, [expanded]
+
+    repo_candidate = (REPO_ROOT / expanded).resolve()
+    script_candidate = (SCRIPT_DIR / expanded).resolve()
+    attempted = [repo_candidate]
+    if script_candidate != repo_candidate:
+        attempted.append(script_candidate)
+
+    for candidate in attempted:
+        if candidate.exists():
+            return candidate, attempted
+    return repo_candidate, attempted
+
+
 def selected_credential_source(config: Config) -> str:
     if config.client_secrets_path.exists():
         return f"GOOGLE_PHOTOS_CLIENT_SECRETS_PATH file ({config.client_secrets_path})"
@@ -179,7 +200,9 @@ def validate_config() -> tuple[Config | None, list[str]]:
     height = record("HEIGHT", default=240, validator=lambda v: _as_int("HEIGHT", v))
     cache_raw = record("CACHE_DIR", default=str(DEFAULT_ROOT / "cache" / "google_photos"))
     fallback_raw = record("FALLBACK_IMAGE", default=str(DEFAULT_ROOT / "images" / "photos-fallback.png"))
-    logo_raw = record("LOGO_PATH", default="/images/goo-photos-icon.png")
+    logo_override_raw = os.getenv("LOGO_PATH")
+    logo_raw = logo_override_raw if logo_override_raw is not None else str(DEFAULT_LOGO_RELATIVE_PATH)
+    logo_path, logo_attempted_paths = resolve_repo_or_script_relative_path(str(logo_raw))
     oauth_port = record("OAUTH_PORT", default=8080, validator=lambda v: _as_int("OAUTH_PORT", v))
     oauth_open_browser = record("OAUTH_OPEN_BROWSER", default=False, validator=_as_bool)
 
@@ -205,7 +228,8 @@ def validate_config() -> tuple[Config | None, list[str]]:
         height=int(height),
         cache_dir=Path(str(cache_raw)).expanduser(),
         fallback_image=fallback_image,
-        logo_path=Path(str(logo_raw)).expanduser(),
+        logo_path=logo_path,
+        logo_attempted_paths=logo_attempted_paths,
         oauth_port=int(oauth_port),
         oauth_open_browser=bool(oauth_open_browser),
     )
@@ -646,6 +670,12 @@ def main() -> int:
         report_validation_errors("photos-shuffle.py", errors)
         return 1
     assert config is not None
+
+    if not config.logo_path.exists():
+        attempted = ", ".join(str(path) for path in config.logo_attempted_paths)
+        log.info(
+            f"WARNING: LOGO_PATH not found; rendering without logo. Tried: {attempted}"
+        )
 
     if args.check_config:
         print(f"[photos-shuffle.py] Credential source: {selected_credential_source(config)}")


### PR DESCRIPTION
### Motivation
- The script previously used an absolute default logo path which can be missing depending on install layout, and it should allow `LOGO_PATH` to remain the highest-priority override.
- Provide a predictable resolution strategy that checks repository-relative and script-relative locations and emit a single informative warning when the logo cannot be found.

### Description
- Introduce `SCRIPT_DIR`, `REPO_ROOT`, and `DEFAULT_LOGO_RELATIVE_PATH` and add `resolve_repo_or_script_relative_path()` to resolve relative logo paths against repo then script locations.
- Keep `LOGO_PATH` as the highest-priority override by reading `os.getenv("LOGO_PATH")` before applying default resolution logic.
- Store resolved `logo_path` and `logo_attempted_paths` in the `Config` dataclass so attempted candidates are tracked.
- Emit a single warning via `log.info()` when the resolved logo file does not exist, listing the attempted paths, and continue rendering without a logo.

### Testing
- Compiled the script with `python3 -m py_compile scripts/photos-shuffle.py`, which succeeded.
- Attempted to run `python3 scripts/photos-shuffle.py --smoke-list-fetch`, but execution aborted with `ModuleNotFoundError: No module named 'dotenv'` due to a missing runtime dependency (`python-dotenv`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad07163ee08320b7b7927e5a25f458)