### PR TITLE
Implement remaining Block F portability/system fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Set at minimum:
 - `PIHOLE_API_TOKEN` (optional fallback)
 - `REFRESH_SECS`
 - `ACTIVE_HOURS` (inclusive `start,end` hour window in 24h format; cross-midnight values like `22,7` are supported)
+- `FB_DEVICE` (optional override; defaults to `/dev/fb1`)
+- `FB_WIDTH` / `FB_HEIGHT` (optional override for static renderer geometry; defaults `320x240`)
 
 ## Run via systemd
 
@@ -132,3 +134,8 @@ Use `python3 scripts/photos-shuffle.py --check-config` to validate the configura
 
 - `display_rotator.py` excludes `piholestats_v1.2.py` by default so day mode and night mode stay distinct.
 - Static image scripts (for example `tram-info.py`, `weather-dash.py`, `calendash-img.py`) are rotator-friendly page scripts, not systemd service units by themselves.
+
+
+### Framebuffer overrides in systemd
+
+Both canonical service units now set `FB_DEVICE=/dev/fb1` by default and load `/opt/zero2dash/.env` afterward, so setting `FB_DEVICE` in `.env` overrides the unit default without editing unit files.

--- a/debug/fix_implementation_report.md
+++ b/debug/fix_implementation_report.md
@@ -4,8 +4,8 @@ This report summarizes the status of the debugging roadmap tasks after the rewri
 
 ## Overall status
 
-- **Implemented:** Tasks **#1 through #21**, plus **#25**.
-- **Remaining (Block F portability/system):** **#22, #23, #24, #26, #27**.
+- **Implemented:** Tasks **#1 through #27**.
+- **Remaining:** None.
 
 ## Implemented fixes
 
@@ -133,62 +133,14 @@ This report summarizes the status of the debugging roadmap tasks after the rewri
   - Key file: `README.md`.
   - Evidence commit: `63cbacd`.
 
-## Remaining fixes to implement (Block F)
+## Remaining fixes to implement
 
-### #22 Static script Pillow compatibility shim
+All previously listed Block F items (#22, #23, #24, #26, #27) are now implemented.
 
-**Status:** Not implemented.
+## Block F completion summary
 
-- Needed change: add a compatibility fallback for `Image.Resampling.LANCZOS` to support older Pillow versions.
-- Target files:
-  - `scripts/calendash-img.py`
-  - `scripts/google-photos.py`
-  - `scripts/tram-info.py`
-  - `scripts/weather-dash.py`
-
-### #23 Parameterize framebuffer path/geometry
-
-**Status:** Not implemented.
-
-- Needed change: configurable framebuffer path, width/height, and robust byte-size validation.
-- Target files:
-  - `scripts/calendash-img.py`
-  - `scripts/google-photos.py`
-  - `scripts/tram-info.py`
-  - `scripts/weather-dash.py`
-
-### #24 Robust touch parsing in `calendash-img.py`
-
-**Status:** Not implemented.
-
-- Needed change: parse full Linux input event stream, handle partial reads, reduce false timeouts, support configurable input device path.
-- Target file:
-  - `scripts/calendash-img.py`
-
-### #26 Make systemd framebuffer path configurable
-
-**Status:** Not implemented.
-
-- Needed change: avoid hard-coded `/dev/fb1` assumptions; pass framebuffer path from environment/override.
-- Target files:
-  - `systemd/display.service`
-  - `systemd/pihole-display-dark.service`
-  - potentially related timer/unit docs in `README.md`
-
-### #27 Harden `pihole-display-pre.sh` dependency checks
-
-**Status:** Not implemented.
-
-- Needed change: check availability of `con2fbmap`/`setterm`, guard sysfs writes, and log warnings for skipped operations.
-- Target file:
-  - `scripts/pihole-display-pre.sh`
-
-## Suggested next implementation order for remaining Block F
-
-1. **#22** (low-risk compatibility helper)
-2. **#23** (shared framebuffer configurability)
-3. **#24** (touch-event parser update)
-4. **#26** (systemd wiring for #23)
-5. **#27** (pre-start shell hardening)
-
-This ordering minimizes rework because systemd changes (#26) should reference finalized script flags/env from #23.
+- **#22** Implemented with Pillow resampling compatibility fallback in static render scripts.
+- **#23** Implemented with configurable framebuffer path/geometry and payload-size checks.
+- **#24** Implemented with non-blocking buffered Linux input event parsing in `calendash-img.py`.
+- **#26** Implemented by wiring `FB_DEVICE` into canonical systemd services and removing hard-coded fb device unit dependencies.
+- **#27** Implemented with command-presence checks, sysfs write guards, and warning logs in pre-start shell script.

--- a/scripts/calendash-img.py
+++ b/scripts/calendash-img.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import mmap
+import os
 import select
 import struct
 import sys
@@ -13,13 +14,15 @@ from pathlib import Path
 
 from PIL import Image
 
-FBDEV_DEFAULT = "/dev/fb1"
-TOUCH_DEVICE_DEFAULT = "/dev/input/event0"
-W, H = 320, 240
+FBDEV_DEFAULT = os.environ.get("FB_DEVICE", "/dev/fb1")
+TOUCH_DEVICE_DEFAULT = os.environ.get("TOUCH_DEVICE", "/dev/input/event0")
+WIDTH_DEFAULT = int(os.environ.get("FB_WIDTH", "320"))
+HEIGHT_DEFAULT = int(os.environ.get("FB_HEIGHT", "240"))
 DEFAULT_IMAGE = Path(__file__).resolve().parent.parent / "images" / "calendash" / "output.png"
 INPUT_EVENT_STRUCT = struct.Struct("llHHI")
 EV_KEY = 0x01
 BTN_TOUCH = 0x14A
+RESAMPLING_LANCZOS = getattr(getattr(Image, "Resampling", Image), "LANCZOS")
 
 
 def rgb888_to_rgb565(image: Image.Image) -> bytes:
@@ -36,16 +39,20 @@ def rgb888_to_rgb565(image: Image.Image) -> bytes:
     return bytes(rgb565)
 
 
-def load_frame(image_path: Path) -> Image.Image:
+def load_frame(image_path: Path, width: int, height: int) -> Image.Image:
     if not image_path.exists():
         raise FileNotFoundError(f"Background image not found: {image_path}")
-    return Image.open(image_path).convert("RGB").resize((W, H), Image.Resampling.LANCZOS)
+    return Image.open(image_path).convert("RGB").resize((width, height), RESAMPLING_LANCZOS)
 
 
-def write_to_framebuffer(image: Image.Image, fbdev: str) -> None:
+def write_to_framebuffer(image: Image.Image, fbdev: str, width: int, height: int) -> None:
     payload = rgb888_to_rgb565(image)
+    expected = width * height * 2
+    if len(payload) != expected:
+        raise RuntimeError(f"Framebuffer payload size mismatch: expected {expected} bytes, got {len(payload)} bytes")
+
     with open(fbdev, "r+b", buffering=0) as framebuffer:
-        mm = mmap.mmap(framebuffer.fileno(), W * H * 2, mmap.MAP_SHARED, mmap.PROT_WRITE)
+        mm = mmap.mmap(framebuffer.fileno(), expected, mmap.MAP_SHARED, mmap.PROT_WRITE)
         mm.seek(0)
         mm.write(payload)
         mm.close()
@@ -58,29 +65,39 @@ def wait_for_touch_or_timeout(device_path: Path, timeout_s: float) -> str:
         time.sleep(max(0.0, timeout_s))
         return "timeout"
 
-    with open(device_path, "rb", buffering=0) as touch_dev:
+    fd = os.open(device_path, os.O_RDONLY | os.O_NONBLOCK)
+    try:
+        pending = bytearray()
         while True:
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 return "timeout"
 
-            ready, _, _ = select.select([touch_dev], [], [], remaining)
+            ready, _, _ = select.select([fd], [], [], remaining)
             if not ready:
                 return "timeout"
 
-            payload = touch_dev.read(INPUT_EVENT_STRUCT.size)
-            if len(payload) != INPUT_EVENT_STRUCT.size:
-                return "timeout"
+            chunk = os.read(fd, 4096)
+            if not chunk:
+                continue
 
-            _, _, event_type, code, value = INPUT_EVENT_STRUCT.unpack(payload)
-            if event_type == EV_KEY and code == BTN_TOUCH and value == 1:
-                return "touch"
+            pending.extend(chunk)
+            while len(pending) >= INPUT_EVENT_STRUCT.size:
+                payload = bytes(pending[: INPUT_EVENT_STRUCT.size])
+                del pending[: INPUT_EVENT_STRUCT.size]
+                _, _, event_type, code, value = INPUT_EVENT_STRUCT.unpack(payload)
+                if event_type == EV_KEY and code == BTN_TOUCH and value == 1:
+                    return "touch"
+    finally:
+        os.close(fd)
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Display calendash image then wait for touch/timeout.")
     parser.add_argument("--image", default=str(DEFAULT_IMAGE), help=f"Image path (default: {DEFAULT_IMAGE})")
     parser.add_argument("--fbdev", default=FBDEV_DEFAULT, help=f"Framebuffer device path (default: {FBDEV_DEFAULT})")
+    parser.add_argument("--width", type=int, default=WIDTH_DEFAULT, help=f"Framebuffer width (default: {WIDTH_DEFAULT})")
+    parser.add_argument("--height", type=int, default=HEIGHT_DEFAULT, help=f"Framebuffer height (default: {HEIGHT_DEFAULT})")
     parser.add_argument(
         "--touch-device",
         default=TOUCH_DEVICE_DEFAULT,
@@ -101,7 +118,7 @@ def main() -> int:
     args = parse_args()
 
     try:
-        frame = load_frame(Path(args.image))
+        frame = load_frame(Path(args.image), args.width, args.height)
     except FileNotFoundError as exc:
         print(exc, file=sys.stderr)
         return 1
@@ -123,7 +140,11 @@ def main() -> int:
         print("Timeout cannot be negative.", file=sys.stderr)
         return 1
 
-    write_to_framebuffer(frame, args.fbdev)
+    if args.width <= 0 or args.height <= 0:
+        print("Width/height must be positive integers.", file=sys.stderr)
+        return 1
+
+    write_to_framebuffer(frame, args.fbdev, args.width, args.height)
     print(f"Displayed calendash image on {args.fbdev}")
 
     trigger = wait_for_touch_or_timeout(Path(args.touch_device), args.timeout)

--- a/scripts/google-photos.py
+++ b/scripts/google-photos.py
@@ -3,15 +3,19 @@
 
 import argparse
 import mmap
+import os
 import struct
 import sys
 from pathlib import Path
 
 from PIL import Image
 
-FBDEV_DEFAULT = "/dev/fb1"
-W, H = 320, 240
+FBDEV_DEFAULT = os.environ.get("FB_DEVICE", "/dev/fb1")
+WIDTH_DEFAULT = int(os.environ.get("FB_WIDTH", "320"))
+HEIGHT_DEFAULT = int(os.environ.get("FB_HEIGHT", "240"))
 DEFAULT_IMAGE = Path(__file__).resolve().parent.parent / "images" / "google-photos-temp.png"
+
+RESAMPLING_LANCZOS = getattr(getattr(Image, "Resampling", Image), "LANCZOS")
 
 
 def rgb888_to_rgb565(image: Image.Image) -> bytes:
@@ -28,16 +32,20 @@ def rgb888_to_rgb565(image: Image.Image) -> bytes:
     return bytes(rgb565)
 
 
-def load_frame(image_path: Path) -> Image.Image:
+def load_frame(image_path: Path, width: int, height: int) -> Image.Image:
     if not image_path.exists():
         raise FileNotFoundError(f"Background image not found: {image_path}")
-    return Image.open(image_path).convert("RGB").resize((W, H), Image.Resampling.LANCZOS)
+    return Image.open(image_path).convert("RGB").resize((width, height), RESAMPLING_LANCZOS)
 
 
-def write_to_framebuffer(image: Image.Image, fbdev: str) -> None:
+def write_to_framebuffer(image: Image.Image, fbdev: str, width: int, height: int) -> None:
     payload = rgb888_to_rgb565(image)
+    expected = width * height * 2
+    if len(payload) != expected:
+        raise RuntimeError(f"Framebuffer payload size mismatch: expected {expected} bytes, got {len(payload)} bytes")
+
     with open(fbdev, "r+b", buffering=0) as framebuffer:
-        mm = mmap.mmap(framebuffer.fileno(), W * H * 2, mmap.MAP_SHARED, mmap.PROT_WRITE)
+        mm = mmap.mmap(framebuffer.fileno(), expected, mmap.MAP_SHARED, mmap.PROT_WRITE)
         mm.seek(0)
         mm.write(payload)
         mm.close()
@@ -47,6 +55,8 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Display google-photos background image on TFT framebuffer.")
     parser.add_argument("--image", default=str(DEFAULT_IMAGE), help=f"Background image path (default: {DEFAULT_IMAGE})")
     parser.add_argument("--fbdev", default=FBDEV_DEFAULT, help=f"Framebuffer device path (default: {FBDEV_DEFAULT})")
+    parser.add_argument("--width", type=int, default=WIDTH_DEFAULT, help=f"Framebuffer width (default: {WIDTH_DEFAULT})")
+    parser.add_argument("--height", type=int, default=HEIGHT_DEFAULT, help=f"Framebuffer height (default: {HEIGHT_DEFAULT})")
     parser.add_argument("--output", help="Optional output image path for local verification (PNG/JPG)")
     parser.add_argument("--no-framebuffer", action="store_true", help="Skip framebuffer write (useful for local testing).")
     return parser.parse_args()
@@ -56,7 +66,7 @@ def main() -> int:
     args = parse_args()
 
     try:
-        frame = load_frame(Path(args.image))
+        frame = load_frame(Path(args.image), args.width, args.height)
     except FileNotFoundError as exc:
         print(exc, file=sys.stderr)
         return 1
@@ -74,7 +84,11 @@ def main() -> int:
         print(f"Framebuffer {args.fbdev} not found.", file=sys.stderr)
         return 1
 
-    write_to_framebuffer(frame, args.fbdev)
+    if args.width <= 0 or args.height <= 0:
+        print("Width/height must be positive integers.", file=sys.stderr)
+        return 1
+
+    write_to_framebuffer(frame, args.fbdev, args.width, args.height)
     print(f"Displayed google-photos background on {args.fbdev}")
     return 0
 

--- a/scripts/pihole-display-pre.sh
+++ b/scripts/pihole-display-pre.sh
@@ -1,7 +1,33 @@
 #!/bin/sh
-# Keep the Linux console off the SPI framebuffer and hide the cursor
-con2fbmap 1 0 2>/dev/null || true
-setterm -cursor off < /dev/tty1 2>/dev/null || true
-echo 0 > /sys/class/graphics/fbcon/cursor_blink 2>/dev/null || true
-# Give the fb driver a moment to settle
+# Keep the Linux console off the configured framebuffer and hide the cursor.
+
+FB_DEVICE="${FB_DEVICE:-/dev/fb1}"
+FB_NUM="${FB_DEVICE#/dev/fb}"
+
+if command -v con2fbmap >/dev/null 2>&1; then
+    if ! con2fbmap 1 "${FB_NUM}" 2>/dev/null; then
+        echo "[pre] warning: con2fbmap failed for ${FB_DEVICE}" >&2
+    fi
+else
+    echo "[pre] warning: con2fbmap not found; skipping console remap" >&2
+fi
+
+if command -v setterm >/dev/null 2>&1; then
+    if ! setterm -cursor off < /dev/tty1 2>/dev/null; then
+        echo "[pre] warning: setterm failed on /dev/tty1" >&2
+    fi
+else
+    echo "[pre] warning: setterm not found; skipping cursor hide" >&2
+fi
+
+CURSOR_BLINK_PATH=/sys/class/graphics/fbcon/cursor_blink
+if [ -w "${CURSOR_BLINK_PATH}" ]; then
+    if ! echo 0 > "${CURSOR_BLINK_PATH}" 2>/dev/null; then
+        echo "[pre] warning: unable to disable cursor blink" >&2
+    fi
+else
+    echo "[pre] warning: ${CURSOR_BLINK_PATH} is not writable; skipping" >&2
+fi
+
+# Give the fb driver a moment to settle.
 sleep 2

--- a/scripts/tram-info.py
+++ b/scripts/tram-info.py
@@ -3,15 +3,19 @@
 
 import argparse
 import mmap
+import os
 import struct
 import sys
 from pathlib import Path
 
 from PIL import Image
 
-FBDEV_DEFAULT = "/dev/fb1"
-W, H = 320, 240
+FBDEV_DEFAULT = os.environ.get("FB_DEVICE", "/dev/fb1")
+WIDTH_DEFAULT = int(os.environ.get("FB_WIDTH", "320"))
+HEIGHT_DEFAULT = int(os.environ.get("FB_HEIGHT", "240"))
 DEFAULT_IMAGE = Path(__file__).resolve().parent.parent / "images" / "bee-net-temp.png"
+
+RESAMPLING_LANCZOS = getattr(getattr(Image, "Resampling", Image), "LANCZOS")
 
 
 def rgb888_to_rgb565(image: Image.Image) -> bytes:
@@ -28,16 +32,20 @@ def rgb888_to_rgb565(image: Image.Image) -> bytes:
     return bytes(rgb565)
 
 
-def load_frame(image_path: Path) -> Image.Image:
+def load_frame(image_path: Path, width: int, height: int) -> Image.Image:
     if not image_path.exists():
         raise FileNotFoundError(f"Background image not found: {image_path}")
-    return Image.open(image_path).convert("RGB").resize((W, H), Image.Resampling.LANCZOS)
+    return Image.open(image_path).convert("RGB").resize((width, height), RESAMPLING_LANCZOS)
 
 
-def write_to_framebuffer(image: Image.Image, fbdev: str) -> None:
+def write_to_framebuffer(image: Image.Image, fbdev: str, width: int, height: int) -> None:
     payload = rgb888_to_rgb565(image)
+    expected = width * height * 2
+    if len(payload) != expected:
+        raise RuntimeError(f"Framebuffer payload size mismatch: expected {expected} bytes, got {len(payload)} bytes")
+
     with open(fbdev, "r+b", buffering=0) as framebuffer:
-        mm = mmap.mmap(framebuffer.fileno(), W * H * 2, mmap.MAP_SHARED, mmap.PROT_WRITE)
+        mm = mmap.mmap(framebuffer.fileno(), expected, mmap.MAP_SHARED, mmap.PROT_WRITE)
         mm.seek(0)
         mm.write(payload)
         mm.close()
@@ -47,6 +55,8 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Display tram-info background image on TFT framebuffer.")
     parser.add_argument("--image", default=str(DEFAULT_IMAGE), help=f"Background image path (default: {DEFAULT_IMAGE})")
     parser.add_argument("--fbdev", default=FBDEV_DEFAULT, help=f"Framebuffer device path (default: {FBDEV_DEFAULT})")
+    parser.add_argument("--width", type=int, default=WIDTH_DEFAULT, help=f"Framebuffer width (default: {WIDTH_DEFAULT})")
+    parser.add_argument("--height", type=int, default=HEIGHT_DEFAULT, help=f"Framebuffer height (default: {HEIGHT_DEFAULT})")
     parser.add_argument("--output", help="Optional output image path for local verification (PNG/JPG)")
     parser.add_argument("--no-framebuffer", action="store_true", help="Skip framebuffer write (useful for local testing).")
     return parser.parse_args()
@@ -56,7 +66,7 @@ def main() -> int:
     args = parse_args()
 
     try:
-        frame = load_frame(Path(args.image))
+        frame = load_frame(Path(args.image), args.width, args.height)
     except FileNotFoundError as exc:
         print(exc, file=sys.stderr)
         return 1
@@ -74,7 +84,11 @@ def main() -> int:
         print(f"Framebuffer {args.fbdev} not found.", file=sys.stderr)
         return 1
 
-    write_to_framebuffer(frame, args.fbdev)
+    if args.width <= 0 or args.height <= 0:
+        print("Width/height must be positive integers.", file=sys.stderr)
+        return 1
+
+    write_to_framebuffer(frame, args.fbdev, args.width, args.height)
     print(f"Displayed tram-info background on {args.fbdev}")
     return 0
 

--- a/scripts/weather-dash.py
+++ b/scripts/weather-dash.py
@@ -3,15 +3,19 @@
 
 import argparse
 import mmap
+import os
 import struct
 import sys
 from pathlib import Path
 
 from PIL import Image
 
-FBDEV_DEFAULT = "/dev/fb1"
-W, H = 320, 240
+FBDEV_DEFAULT = os.environ.get("FB_DEVICE", "/dev/fb1")
+WIDTH_DEFAULT = int(os.environ.get("FB_WIDTH", "320"))
+HEIGHT_DEFAULT = int(os.environ.get("FB_HEIGHT", "240"))
 DEFAULT_IMAGE = Path(__file__).resolve().parent.parent / "images" / "weather-dash-temp.png"
+
+RESAMPLING_LANCZOS = getattr(getattr(Image, "Resampling", Image), "LANCZOS")
 
 
 def rgb888_to_rgb565(image: Image.Image) -> bytes:
@@ -28,16 +32,20 @@ def rgb888_to_rgb565(image: Image.Image) -> bytes:
     return bytes(rgb565)
 
 
-def load_frame(image_path: Path) -> Image.Image:
+def load_frame(image_path: Path, width: int, height: int) -> Image.Image:
     if not image_path.exists():
         raise FileNotFoundError(f"Background image not found: {image_path}")
-    return Image.open(image_path).convert("RGB").resize((W, H), Image.Resampling.LANCZOS)
+    return Image.open(image_path).convert("RGB").resize((width, height), RESAMPLING_LANCZOS)
 
 
-def write_to_framebuffer(image: Image.Image, fbdev: str) -> None:
+def write_to_framebuffer(image: Image.Image, fbdev: str, width: int, height: int) -> None:
     payload = rgb888_to_rgb565(image)
+    expected = width * height * 2
+    if len(payload) != expected:
+        raise RuntimeError(f"Framebuffer payload size mismatch: expected {expected} bytes, got {len(payload)} bytes")
+
     with open(fbdev, "r+b", buffering=0) as framebuffer:
-        mm = mmap.mmap(framebuffer.fileno(), W * H * 2, mmap.MAP_SHARED, mmap.PROT_WRITE)
+        mm = mmap.mmap(framebuffer.fileno(), expected, mmap.MAP_SHARED, mmap.PROT_WRITE)
         mm.seek(0)
         mm.write(payload)
         mm.close()
@@ -47,6 +55,8 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Display weather-dash background image on TFT framebuffer.")
     parser.add_argument("--image", default=str(DEFAULT_IMAGE), help=f"Background image path (default: {DEFAULT_IMAGE})")
     parser.add_argument("--fbdev", default=FBDEV_DEFAULT, help=f"Framebuffer device path (default: {FBDEV_DEFAULT})")
+    parser.add_argument("--width", type=int, default=WIDTH_DEFAULT, help=f"Framebuffer width (default: {WIDTH_DEFAULT})")
+    parser.add_argument("--height", type=int, default=HEIGHT_DEFAULT, help=f"Framebuffer height (default: {HEIGHT_DEFAULT})")
     parser.add_argument("--output", help="Optional output image path for local verification (PNG/JPG)")
     parser.add_argument("--no-framebuffer", action="store_true", help="Skip framebuffer write (useful for local testing).")
     return parser.parse_args()
@@ -56,7 +66,7 @@ def main() -> int:
     args = parse_args()
 
     try:
-        frame = load_frame(Path(args.image))
+        frame = load_frame(Path(args.image), args.width, args.height)
     except FileNotFoundError as exc:
         print(exc, file=sys.stderr)
         return 1
@@ -74,7 +84,11 @@ def main() -> int:
         print(f"Framebuffer {args.fbdev} not found.", file=sys.stderr)
         return 1
 
-    write_to_framebuffer(frame, args.fbdev)
+    if args.width <= 0 or args.height <= 0:
+        print("Width/height must be positive integers.", file=sys.stderr)
+        return 1
+
+    write_to_framebuffer(frame, args.fbdev, args.width, args.height)
     print(f"Displayed weather-dash background on {args.fbdev}")
     return 0
 

--- a/systemd/display.service
+++ b/systemd/display.service
@@ -1,13 +1,13 @@
 [Unit]
 Description=Pi-hole TFT Day Display Rotator
-After=network-online.target dev-fb1.device
-Wants=network-online.target dev-fb1.device
-ConditionPathExists=/dev/fb1
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=simple
 WorkingDirectory=/opt/zero2dash
 Environment=PYTHONUNBUFFERED=1
+Environment=FB_DEVICE=/dev/fb1
 EnvironmentFile=-/opt/zero2dash/.env
 
 ExecStartPre=/opt/zero2dash/scripts/pihole-display-pre.sh

--- a/systemd/pihole-display-dark.service
+++ b/systemd/pihole-display-dark.service
@@ -1,13 +1,13 @@
 [Unit]
 Description=Pi-hole TFT Stats Display DARK
-After=network-online.target dev-fb1.device
-Wants=network-online.target dev-fb1.device
-ConditionPathExists=/dev/fb1
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=simple
 WorkingDirectory=/opt/zero2dash
 Environment=PYTHONUNBUFFERED=1
+Environment=FB_DEVICE=/dev/fb1
 EnvironmentFile=-/opt/zero2dash/.env
 
 ExecStartPre=/opt/zero2dash/scripts/pihole-display-pre.sh


### PR DESCRIPTION
### Motivation
- Complete the remaining Block F portability and system hardening tasks from the fix report to improve cross-Pillow compatibility, make framebuffer path/geometry configurable, robustly handle touch input, and harden systemd startup prechecks.
- Avoid brittle assumptions about `/dev/fb1` and older Pillow APIs that prevented the static renderers and service units from running reliably across environments.

### Description
- Added a Pillow resampling compatibility fallback and replaced direct `Image.Resampling.LANCZOS` usage with a `RESAMPLING_LANCZOS` accessor in static renderer scripts (`scripts/calendash-img.py`, `scripts/google-photos.py`, `scripts/tram-info.py`, `scripts/weather-dash.py`).
- Parameterised framebuffer device and geometry via env-vars `FB_DEVICE`, `FB_WIDTH`, `FB_HEIGHT` and added CLI flags `--width`/`--height`, plus payload-size validation before `mmap` writes in the same static renderer scripts to prevent mismatched writes.
- Reworked touch input handling in `scripts/calendash-img.py` to use non-blocking buffered reads of the Linux input event stream and assemble partial event chunks to avoid false timeouts and missed events.
- Made systemd units environment-driven by removing hard-coded `/dev/fb1` unit dependencies and adding `Environment=FB_DEVICE=/dev/fb1` (overridable via `.env`), and hardened the pre-start script (`scripts/pihole-display-pre.sh`) with `con2fbmap`/`setterm` presence checks and guarded sysfs writes; updated `README.md` and the debug report to reflect these changes.

### Testing
- Ran Python compilation across the repository with `python3 -m py_compile $(rg --files -g '*.py')`, which completed successfully.
- Verified static script module-level compilation with `python3 -m py_compile scripts/calendash-img.py scripts/google-photos.py scripts/tram-info.py scripts/weather-dash.py scripts/piholestats_v1.2.py display_rotator.py`, which succeeded.
- Performed a shell syntax check `sh -n scripts/pihole-display-pre.sh`, which succeeded, and ran `systemd-analyze verify` which ran but produced environment/path warnings in this container due to `/opt/zero2dash` runtime paths not being present (expected in this environment).
- Attempted runtime smoke runs of the static renderers with `--no-framebuffer` and `--output` but they failed in this test container with `ModuleNotFoundError: No module named 'PIL'`, so full runtime image rendering could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad26562f28832092900c0675f1c71c)